### PR TITLE
Implement backtesting engine, MA rolling means, and robust data streaming

### DIFF
--- a/Examples/run_update_service.py
+++ b/Examples/run_update_service.py
@@ -1,14 +1,101 @@
+"""Robust polling loop for the AltoTrader data streaming service.
+
+Fetches Kraken ticker prices every POLL_INTERVAL_SECONDS and writes them to
+InfluxDB. Handles network outages and API errors gracefully:
+
+  - Consecutive failures trigger increasing back-off (up to MAX_BACKOFF_SECONDS)
+  - A summary of success/failure counts is logged every HEARTBEAT_INTERVAL cycles
+  - SIGINT / SIGTERM shut the loop down cleanly
+
+Usage:
+    python Examples/run_update_service.py
+
+Environment variables (see env/ for a template):
+    INFLUXDB_INIT_BUCKET, INFLUXDB_INIT_ORG, INFLUX_URL, INFLUXDB_INIT_ADMIN_TOKEN
+"""
+
+import signal
+import sys
+import time
+import logging
+
 from altotrader.database.update_service import TickerUpdateService
 from altotrader.ticker.krakenticker import KrakenTicker
+from altotrader.logging_config import setup_logging
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+POLL_INTERVAL_SECONDS = 60       # how often to fetch & write prices
+MAX_BACKOFF_SECONDS = 300        # cap for back-off on consecutive failures
+HEARTBEAT_INTERVAL = 10          # log a heartbeat every N successful cycles
+PAIRS_YAML = "Examples/kraken_pairs.yaml"
+LOG_DIR = "logs"
+# ──────────────────────────────────────────────────────────────────────────────
 
 
-def run_update(pair_yaml: str):
-    ticker = KrakenTicker(pairs_yaml=pair_yaml, log_dir='logs')
-    service = TickerUpdateService(ticker)
+def _make_shutdown_handler(stop_flag: list):
+    """Returns a signal handler that sets stop_flag[0] = True."""
+    def handler(signum, frame):
+        logging.getLogger(__name__).info(
+            f"Received signal {signum}, shutting down gracefully...")
+        stop_flag[0] = True
+    return handler
 
-    # Update ticker prices for c, a, b
-    success = service.update_pairs_ticker()
+
+def run_update(pair_yaml: str = PAIRS_YAML):
+    setup_logging(log_filename='run_update_service.logs', log_dir=LOG_DIR)
+    logger = logging.getLogger(__name__)
+
+    ticker = KrakenTicker(pairs_yaml=pair_yaml, log_dir=LOG_DIR)
+    service = TickerUpdateService(ticker, log_dir=LOG_DIR)
+
+    stop_flag = [False]
+    signal.signal(signal.SIGINT, _make_shutdown_handler(stop_flag))
+    signal.signal(signal.SIGTERM, _make_shutdown_handler(stop_flag))
+
+    consecutive_failures = 0
+    total_success = 0
+    total_failure = 0
+    cycle = 0
+
+    logger.info("AltoTrader update service started.")
+
+    while not stop_flag[0]:
+        cycle += 1
+        success = service.update_pairs_ticker()
+
+        if success:
+            consecutive_failures = 0
+            total_success += 1
+            sleep_time = POLL_INTERVAL_SECONDS
+        else:
+            consecutive_failures += 1
+            total_failure += 1
+            # Exponential back-off capped at MAX_BACKOFF_SECONDS
+            backoff = min(POLL_INTERVAL_SECONDS * (2 ** (consecutive_failures - 1)),
+                          MAX_BACKOFF_SECONDS)
+            logger.warning(
+                f"Update failed (consecutive failures: {consecutive_failures}). "
+                f"Backing off for {backoff}s."
+            )
+            sleep_time = backoff
+
+        if cycle % HEARTBEAT_INTERVAL == 0:
+            logger.info(
+                f"[Heartbeat] cycle={cycle} | ok={total_success} | fail={total_failure}"
+            )
+
+        # Interruptible sleep: check stop_flag every second
+        for _ in range(int(sleep_time)):
+            if stop_flag[0]:
+                break
+            time.sleep(1)
+
+    logger.info(
+        f"Update service stopped. Total cycles: {cycle} | "
+        f"success: {total_success} | failure: {total_failure}"
+    )
 
 
 if __name__ == '__main__':
-    run_update(pair_yaml='kraken_pairs.yaml')
+    pair_yaml = sys.argv[1] if len(sys.argv) > 1 else PAIRS_YAML
+    run_update(pair_yaml=pair_yaml)

--- a/src/altotrader/backtest/backtest_engine.py
+++ b/src/altotrader/backtest/backtest_engine.py
@@ -1,19 +1,26 @@
 import pandas as pd
+import numpy as np
+import logging
 
 from altotrader.backtest.dataloader import DataLoader
+from altotrader.logging_config import setup_logging
 
 
 class BacktestEngine:
-    def __init__(self, dataloader: DataLoader, backtest_config: dict):
+    def __init__(self, dataloader: DataLoader, backtest_config: dict, log_dir: str = 'logs'):
         self.dataloader = dataloader
-        self.maker_fee = backtest_config.get('maker_fee')
-        self.taker_fee = backtest_config.get('taker_fee')
-        self.initial_invest = backtest_config.get('initial_invest')
+        self.maker_fee = backtest_config.get('maker_fee', 0.0025)
+        self.taker_fee = backtest_config.get('taker_fee', 0.004)
+        self.initial_invest = backtest_config.get('initial_invest', 1000)
         self.trading_currency = backtest_config.get("trading_currency")
         self.base_currency = backtest_config.get("base_currency")
-        self.pair = self.trading_currency+self.base_currency
+        self.pair = self.trading_currency + self.base_currency
+
+        setup_logging(log_filename='backtest.logs', log_dir=log_dir)
+        self.logger = logging.getLogger(__name__)
 
         self.portfolio_view = pd.DataFrame()
+        self.trade_log: list[dict] = []
 
         # load crypto ticker data
         self.dataloader.load_csv_export()
@@ -21,35 +28,243 @@ class BacktestEngine:
         self._set_portfolio_view_df()
 
     def _set_portfolio_view_df(self):
-        """creates a dataframe (portfolio_view) that stores all relevant information such as,
+        """Creates a dataframe (portfolio_view) that stores all relevant information such as
         current, ask, bid prices, market position etc.
-        Needs to be resetted for every run."""
+        Resets state for every new run."""
+
+        self.portfolio_view = pd.DataFrame(index=self.dataloader.ticker_current.index)
 
         self.portfolio_view[self.pair] = self.dataloader.ticker_current[self.pair]
-        self.portfolio_view[self.pair +
-                            '_ask'] = self.dataloader.ticker_ask[self.pair]
-        self.portfolio_view[self.pair +
-                            '_bid'] = self.dataloader.ticker_bid[self.pair]
+        self.portfolio_view[self.pair + '_ask'] = self.dataloader.ticker_ask[self.pair]
+        self.portfolio_view[self.pair + '_bid'] = self.dataloader.ticker_bid[self.pair]
 
-        self.portfolio_view[self.base_currency] = self.initial_invest
-        self.portfolio_view[self.trading_currency] = 0
-        self.portfolio_view['portfolio_in_'+self.base_currency] = None
-        self.portfolio_view["market_position"] = None
+        self.portfolio_view[self.base_currency] = float(self.initial_invest)
+        self.portfolio_view[self.trading_currency] = 0.0
+        self.portfolio_view['portfolio_in_' + self.base_currency] = float(self.initial_invest)
+        self.portfolio_view["market_position"] = "out"
         self.portfolio_view["action"] = None
 
-        # TODO add columns for long and short rolling means
+        self.trade_log = []
 
-    def enter_market(self):
-        # do stuff
-        pass
+    def enter_market(self, idx: int, row: pd.Series):
+        """Buy trading currency at ask price using all available base currency.
 
-    def exit_market(self):
-        # do stuff
-        pass
+        Args:
+            idx: integer index into portfolio_view
+            row: current row of portfolio_view
+        """
+        base_balance = self.portfolio_view.iloc[idx - 1][self.base_currency] if idx > 0 else self.initial_invest
+        ask_price = row[self.pair + '_ask']
 
-    def upadte_portfolio(self):
-        # do stuff
-        pass
+        if base_balance <= 0 or ask_price <= 0:
+            return
+
+        # Buy amount after taker fee
+        trade_cost = base_balance
+        fee = trade_cost * self.taker_fee
+        amount_bought = (trade_cost - fee) / ask_price
+
+        self.portfolio_view.at[row.name, self.base_currency] = 0.0
+        self.portfolio_view.at[row.name, self.trading_currency] = amount_bought
+        self.portfolio_view.at[row.name, 'market_position'] = 'in'
+        self.portfolio_view.at[row.name, 'action'] = 'buy'
+        self.portfolio_view.at[row.name, 'portfolio_in_' + self.base_currency] = amount_bought * ask_price
+
+        self.trade_log.append({
+            'timestamp': row.name,
+            'action': 'buy',
+            'price': ask_price,
+            'amount': amount_bought,
+            'fee': fee,
+            self.base_currency: 0.0,
+            self.trading_currency: amount_bought,
+        })
+        self.logger.info(f"BUY  @ {ask_price:.2f} | amount: {amount_bought:.6f} | fee: {fee:.4f}")
+
+    def exit_market(self, idx: int, row: pd.Series):
+        """Sell all trading currency at bid price.
+
+        Args:
+            idx: integer index into portfolio_view
+            row: current row of portfolio_view
+        """
+        trading_balance = self.portfolio_view.iloc[idx - 1][self.trading_currency] if idx > 0 else 0.0
+        bid_price = row[self.pair + '_bid']
+
+        if trading_balance <= 0 or bid_price <= 0:
+            return
+
+        # Sell amount after maker fee
+        gross_proceeds = trading_balance * bid_price
+        fee = gross_proceeds * self.maker_fee
+        net_proceeds = gross_proceeds - fee
+
+        self.portfolio_view.at[row.name, self.base_currency] = net_proceeds
+        self.portfolio_view.at[row.name, self.trading_currency] = 0.0
+        self.portfolio_view.at[row.name, 'market_position'] = 'out'
+        self.portfolio_view.at[row.name, 'action'] = 'sell'
+        self.portfolio_view.at[row.name, 'portfolio_in_' + self.base_currency] = net_proceeds
+
+        self.trade_log.append({
+            'timestamp': row.name,
+            'action': 'sell',
+            'price': bid_price,
+            'amount': trading_balance,
+            'fee': fee,
+            self.base_currency: net_proceeds,
+            self.trading_currency: 0.0,
+        })
+        self.logger.info(f"SELL @ {bid_price:.2f} | amount: {trading_balance:.6f} | proceeds: {net_proceeds:.4f} | fee: {fee:.4f}")
+
+    def update_portfolio(self, idx: int, row: pd.Series):
+        """Carry forward balances and update portfolio value when no trade occurs.
+
+        Args:
+            idx: integer index into portfolio_view
+            row: current row of portfolio_view
+        """
+        if idx == 0:
+            return
+
+        prev = self.portfolio_view.iloc[idx - 1]
+        base_bal = prev[self.base_currency]
+        trading_bal = prev[self.trading_currency]
+        current_price = row[self.pair]
+
+        self.portfolio_view.at[row.name, self.base_currency] = base_bal
+        self.portfolio_view.at[row.name, self.trading_currency] = trading_bal
+        self.portfolio_view.at[row.name, 'market_position'] = prev['market_position']
+
+        portfolio_value = base_bal + trading_bal * current_price
+        self.portfolio_view.at[row.name, 'portfolio_in_' + self.base_currency] = portfolio_value
+
+    def run(self, window_short: int, window_long: int) -> dict:
+        """Run the backtest using a moving-average crossover strategy.
+
+        Signal:
+          - BUY  when short MA crosses above long MA (golden cross)
+          - SELL when short MA crosses below long MA (death cross)
+
+        Buy is executed at ask price, sell at bid price.
+
+        Args:
+            window_short: short rolling window in minutes
+            window_long: long rolling window in minutes
+
+        Returns:
+            dict with performance metrics
+        """
+        self.logger.info(f"Starting backtest | short={window_short}min | long={window_long}min")
+        self._set_portfolio_view_df()
+
+        self.dataloader.compute_rolling_means(window_short, window_long)
+
+        ma_short = self.dataloader.rolling_current_short[self.pair]
+        ma_long = self.dataloader.rolling_current_long[self.pair]
+
+        # Align indices
+        self.portfolio_view['ma_short'] = ma_short
+        self.portfolio_view['ma_long'] = ma_long
+
+        # Drop rows where MAs are NaN (warm-up period)
+        valid = self.portfolio_view.dropna(subset=['ma_short', 'ma_long'])
+
+        for idx, (timestamp, row) in enumerate(valid.iterrows()):
+            int_idx = self.portfolio_view.index.get_loc(timestamp)
+
+            if idx == 0:
+                self.update_portfolio(int_idx, row)
+                continue
+
+            prev_short = valid['ma_short'].iloc[idx - 1]
+            prev_long = valid['ma_long'].iloc[idx - 1]
+            curr_short = row['ma_short']
+            curr_long = row['ma_long']
+
+            prev_position = self.portfolio_view.iloc[int_idx - 1]['market_position']
+
+            golden_cross = (prev_short <= prev_long) and (curr_short > curr_long)
+            death_cross = (prev_short >= prev_long) and (curr_short < curr_long)
+
+            if golden_cross and prev_position == 'out':
+                self.enter_market(int_idx, row)
+            elif death_cross and prev_position == 'in':
+                self.exit_market(int_idx, row)
+            else:
+                self.update_portfolio(int_idx, row)
+
+        # Force-close any open position at the last bid price
+        last_idx = len(self.portfolio_view) - 1
+        last_row = self.portfolio_view.iloc[last_idx]
+        if last_row['market_position'] == 'in':
+            self.exit_market(last_idx, last_row)
+            self.portfolio_view.at[last_row.name, 'action'] = 'sell (end)'
+
+        metrics = self.compute_metrics()
+        self.logger.info(f"Backtest complete | return: {metrics['total_return_pct']:.2f}%")
+        return metrics
+
+    def compute_metrics(self) -> dict:
+        """Compute performance metrics after a completed run.
+
+        Returns:
+            dict with keys: total_return_pct, buy_and_hold_return_pct,
+                            n_trades, win_rate, max_drawdown_pct,
+                            sharpe_ratio, total_fees
+        """
+        portfolio_col = 'portfolio_in_' + self.base_currency
+        pv = self.portfolio_view[portfolio_col].dropna()
+
+        initial = float(self.initial_invest)
+        final = float(pv.iloc[-1]) if len(pv) > 0 else initial
+
+        total_return_pct = (final - initial) / initial * 100
+
+        # Buy & Hold: buy at first ask, sell at last bid
+        first_ask = self.portfolio_view[self.pair + '_ask'].dropna().iloc[0]
+        last_bid = self.portfolio_view[self.pair + '_bid'].dropna().iloc[-1]
+        bh_amount = (initial * (1 - self.taker_fee)) / first_ask
+        bh_final = bh_amount * last_bid * (1 - self.maker_fee)
+        bh_return_pct = (bh_final - initial) / initial * 100
+
+        # Trade stats
+        trades_df = pd.DataFrame(self.trade_log)
+        n_trades = len(trades_df[trades_df['action'] == 'sell']) if not trades_df.empty else 0
+
+        wins = 0
+        if not trades_df.empty and n_trades > 0:
+            buys = trades_df[trades_df['action'] == 'buy']['price'].values
+            sells = trades_df[trades_df['action'].str.startswith('sell')]['price'].values
+            pairs = min(len(buys), len(sells))
+            wins = int(np.sum(sells[:pairs] > buys[:pairs]))
+            win_rate = wins / pairs * 100 if pairs > 0 else 0.0
+        else:
+            win_rate = 0.0
+
+        # Max drawdown
+        rolling_max = pv.cummax()
+        drawdown = (pv - rolling_max) / rolling_max * 100
+        max_drawdown_pct = float(drawdown.min())
+
+        # Sharpe ratio (annualised, assuming 1-minute bars)
+        returns = pv.pct_change().dropna()
+        if returns.std() > 0:
+            sharpe = (returns.mean() / returns.std()) * np.sqrt(525_600)  # minutes per year
+        else:
+            sharpe = 0.0
+
+        total_fees = float(trades_df['fee'].sum()) if not trades_df.empty else 0.0
+
+        return {
+            'total_return_pct': round(total_return_pct, 4),
+            'buy_and_hold_return_pct': round(bh_return_pct, 4),
+            'n_trades': n_trades,
+            'win_rate': round(win_rate, 2),
+            'max_drawdown_pct': round(max_drawdown_pct, 4),
+            'sharpe_ratio': round(sharpe, 4),
+            'total_fees': round(total_fees, 4),
+            'final_portfolio_value': round(final, 4),
+        }
 
 
 if __name__ == '__main__':
@@ -66,3 +281,8 @@ if __name__ == '__main__':
     }
 
     backtest = BacktestEngine(testloader, backtest_config)
+    metrics = backtest.run(window_short=50, window_long=200)
+
+    print("\n=== Backtest Results ===")
+    for k, v in metrics.items():
+        print(f"  {k}: {v}")

--- a/src/altotrader/backtest/dataloader.py
+++ b/src/altotrader/backtest/dataloader.py
@@ -71,7 +71,7 @@ class DataLoader:
         self._window_long = window_long
         self._window_short = window_short
 
-        if self.ticker_current.all() is None or self.ticker_ask.all() is None or self.ticker_bid.all() is None:
+        if self.ticker_current is None or self.ticker_ask is None or self.ticker_bid is None:
             self.load_csv_export()
 
         self.rolling_ask_short = self.ticker_ask.rolling(

--- a/src/altotrader/backtest/dataloader.py
+++ b/src/altotrader/backtest/dataloader.py
@@ -74,17 +74,17 @@ class DataLoader:
         if self.ticker_current.all() is None or self.ticker_ask.all() is None or self.ticker_bid.all() is None:
             self.load_csv_export()
 
-        # self.rolling_ask_short = self.ticker_ask.rolling(
-        #     f'{window_short}min').mean()
-        # self.rolling_bid_short = self.ticker_bid.rolling(
-        #     f'{window_short}min').mean()
+        self.rolling_ask_short = self.ticker_ask.rolling(
+            f'{window_short}min').mean()
+        self.rolling_bid_short = self.ticker_bid.rolling(
+            f'{window_short}min').mean()
         self.rolling_current_short = self.ticker_current.rolling(
             f'{window_short}min').mean()
 
-        # self.rolling_ask_long = self.ticker_ask.rolling(
-        #     f'{window_long}min').mean()
-        # self.rolling_bid_long = self.ticker_bid.rolling(
-        #     f'{window_long}min').mean()
+        self.rolling_ask_long = self.ticker_ask.rolling(
+            f'{window_long}min').mean()
+        self.rolling_bid_long = self.ticker_bid.rolling(
+            f'{window_long}min').mean()
         self.rolling_current_long = self.ticker_current.rolling(
             f'{window_long}min').mean()
 

--- a/src/altotrader/database/update_service.py
+++ b/src/altotrader/database/update_service.py
@@ -159,6 +159,10 @@ class TickerUpdateService:
             if hasattr(e, 'response') and e.response:
                 self.logger.error(f"Response details: {e.response.text}")
             return False
+        except Exception as e:
+            # Catches ConnectionError, TimeoutError, etc. so retry logic still works
+            self.logger.error(f"Unexpected error writing to InfluxDB: {str(e)}")
+            return False
 
     def _write_points_with_retry(self, points: list, config: dict) -> bool:
         """Write points to InfluxDB with exponential backoff retry.

--- a/src/altotrader/database/update_service.py
+++ b/src/altotrader/database/update_service.py
@@ -1,4 +1,5 @@
 import os
+import time
 from influxdb_client import InfluxDBClient, Point
 from influxdb_client.client.write_api import SYNCHRONOUS
 from influxdb_client.client.exceptions import InfluxDBError
@@ -9,6 +10,9 @@ import pandas as pd
 from altotrader.ticker.krakenticker import KrakenTicker
 from altotrader.ticker.baseticker import BaseTicker
 from altotrader.logging_config import setup_logging
+
+_MAX_RETRIES = 4
+_RETRY_BASE_DELAY = 2  # seconds (doubles each attempt: 2, 4, 8, 16)
 
 
 class TickerUpdateService:
@@ -33,8 +37,10 @@ class TickerUpdateService:
                             url: Optional[str] = None,
                             token: Optional[str] = None) -> bool:
         """Updates the InfluxDB with market prices for different crypto pairs.
+        Retries the Kraken API fetch up to _MAX_RETRIES times with exponential backoff.
 
         Args:
+            ticker_entry: 'a', 'b', or 'c' (or None for all three)
             bucket: InfluxDB bucket name (falls back to INFLUXDB_INIT_BUCKET env var)
             org: InfluxDB organization (falls back to INFLUXDB_INIT_ORG env var)
             url: InfluxDB URL (falls back to INFLUX_URL env var)
@@ -58,16 +64,16 @@ class TickerUpdateService:
                 raise ValueError(
                     f"Missing configuration: {', '.join(missing)}")
 
-            ticker_entries = [
-                ticker_entry] if ticker_entry else ["a", "b", "c"]
+            ticker_entries = [ticker_entry] if ticker_entry else ["a", "b", "c"]
             all_points = []
 
-            market_query = self.ticker.get_market_query()
+            market_query = self._fetch_market_query_with_retry()
+            if not market_query:
+                self.logger.error("Could not fetch market data after retries")
+                return False
 
             for entry in ticker_entries:
-
-                self.logger.info(
-                    f"Fetching prices for ticker_entry '{entry}'...")
+                self.logger.info(f"Fetching prices for ticker_entry '{entry}'...")
 
                 df = self.ticker.get_last_ticker(
                     ticker_entry=entry, market_query=market_query)
@@ -84,13 +90,34 @@ class TickerUpdateService:
                     "No valid market data found for any ticker entry")
                 return False
 
-            # Write to InfluxDB
-            return self._write_points(all_points, influx_config)
+            # Write to InfluxDB with retry
+            return self._write_points_with_retry(all_points, influx_config)
 
         except Exception as e:
             self.logger.error(
                 f"Unexpected error in price update: {str(e)}", exc_info=True)
             return False
+
+    def _fetch_market_query_with_retry(self) -> dict:
+        """Fetch market data from Kraken with exponential backoff retry.
+
+        Returns:
+            dict with market data, or empty dict on failure.
+        """
+        delay = _RETRY_BASE_DELAY
+        for attempt in range(1, _MAX_RETRIES + 1):
+            result = self.ticker.get_market_query()
+            if result:
+                return result
+            if attempt < _MAX_RETRIES:
+                self.logger.warning(
+                    f"Market query returned empty (attempt {attempt}/{_MAX_RETRIES}), "
+                    f"retrying in {delay}s..."
+                )
+                time.sleep(delay)
+                delay *= 2
+        self.logger.error(f"Market query failed after {_MAX_RETRIES} attempts")
+        return {}
 
     def _generate_points(self, df: pd.DataFrame, ticker_entry: str) -> list:
         """Convert DataFrame to InfluxDB points."""
@@ -107,7 +134,7 @@ class TickerUpdateService:
         return points
 
     def _write_points(self, points: list, config: dict) -> bool:
-        """Write points to InfluxDB."""
+        """Write points to InfluxDB (single attempt)."""
         if not points:
             self.logger.warning("No points to write")
             return False
@@ -132,6 +159,31 @@ class TickerUpdateService:
             if hasattr(e, 'response') and e.response:
                 self.logger.error(f"Response details: {e.response.text}")
             return False
+
+    def _write_points_with_retry(self, points: list, config: dict) -> bool:
+        """Write points to InfluxDB with exponential backoff retry.
+
+        Args:
+            points: list of InfluxDB Point objects
+            config: dict with url, token, bucket, org
+
+        Returns:
+            bool: True if write succeeded within retry budget.
+        """
+        delay = _RETRY_BASE_DELAY
+        for attempt in range(1, _MAX_RETRIES + 1):
+            success = self._write_points(points, config)
+            if success:
+                return True
+            if attempt < _MAX_RETRIES:
+                self.logger.warning(
+                    f"InfluxDB write failed (attempt {attempt}/{_MAX_RETRIES}), "
+                    f"retrying in {delay}s..."
+                )
+                time.sleep(delay)
+                delay *= 2
+        self.logger.error(f"InfluxDB write failed after {_MAX_RETRIES} attempts")
+        return False
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- BacktestEngine: implement enter_market(), exit_market(), update_portfolio()
  with realistic ask/bid execution prices and fee deduction
- BacktestEngine: add run() method with MA golden/death cross signal logic
- BacktestEngine: add compute_metrics() with total return, buy-and-hold
  comparison, win rate, max drawdown, Sharpe ratio, and total fees
- DataLoader: activate rolling means for ask and bid (were commented out)
- TickerUpdateService: add _fetch_market_query_with_retry() and
  _write_points_with_retry() with exponential backoff (2/4/8/16s, 4 retries)
- run_update_service.py: replace bare one-shot call with robust polling loop
  including back-off on consecutive failures, heartbeat logging, and clean
  SIGINT/SIGTERM shutdown

https://claude.ai/code/session_01HQU7KNPmCQP8eZm9DcY7cf