### PR TITLE
Backtesting engine, robust streaming & Docker/Hetzner deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 # ignored files
 venv
 .venv
+
+# Secrets – never commit actual env files
+.env
+*.env
+!env/.env.example   # keep the template
 .vscode/*
 .vscode
 dev.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.11-slim
+
+# Install only what's needed to build C extensions (e.g. pyarrow)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install the altotrader package from pyproject.toml
+COPY pyproject.toml .
+COPY src/ src/
+RUN pip install --no-cache-dir .
+
+# Copy runtime files needed by the streamer
+COPY Examples/ Examples/
+
+CMD ["python", "Examples/run_update_service.py"]

--- a/Examples/fetch_from_remote.py
+++ b/Examples/fetch_from_remote.py
@@ -1,0 +1,125 @@
+"""Fetch ticker data from a remote (e.g. Hetzner) InfluxDB instance and save
+it locally as CSV files, ready for the DataLoader / backtesting pipeline.
+
+Usage
+-----
+Set the connection details either via environment variables or by editing the
+constants below, then run:
+
+    python Examples/fetch_from_remote.py
+
+Or pass the Hetzner IP directly:
+
+    INFLUX_URL=http://<hetzner-ip>:8086 python Examples/fetch_from_remote.py
+
+The exported CSV files land in Examples/ticker_export/ and follow the naming
+convention expected by DataLoader:
+
+    krakenticker_latest_<N>d_a.csv   (ask)
+    krakenticker_latest_<N>d_b.csv   (bid)
+    krakenticker_latest_<N>d_c.csv   (current/close)
+"""
+
+import os
+import sys
+import argparse
+import logging
+
+# Allow running from project root without installing the package
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from altotrader.database.export_prices import export_prices
+from altotrader.logging_config import setup_logging
+
+# ── Defaults (override via env vars or CLI flags) ────────────────────────────
+DEFAULT_OUTPUT_DIR = "Examples/ticker_export"
+DEFAULT_DAYS = 20
+DEFAULT_FORMAT = "csv"      # "csv" or "parquet"
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Export ticker data from a remote InfluxDB to local files."
+    )
+    parser.add_argument(
+        "--url",
+        default=os.getenv("INFLUX_URL", "http://localhost:8086"),
+        help="InfluxDB URL, e.g. http://<hetzner-ip>:8086  (env: INFLUX_URL)",
+    )
+    parser.add_argument(
+        "--token",
+        default=os.getenv("INFLUXDB_INIT_ADMIN_TOKEN"),
+        help="InfluxDB admin token  (env: INFLUXDB_INIT_ADMIN_TOKEN)",
+    )
+    parser.add_argument(
+        "--org",
+        default=os.getenv("INFLUXDB_INIT_ORG"),
+        help="InfluxDB organisation  (env: INFLUXDB_INIT_ORG)",
+    )
+    parser.add_argument(
+        "--bucket",
+        default=os.getenv("INFLUXDB_INIT_BUCKET"),
+        help="InfluxDB bucket  (env: INFLUXDB_INIT_BUCKET)",
+    )
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=DEFAULT_DAYS,
+        help=f"How many days of history to fetch (default: {DEFAULT_DAYS})",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["csv", "parquet"],
+        default=DEFAULT_FORMAT,
+        help=f"Output file format (default: {DEFAULT_FORMAT})",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=DEFAULT_OUTPUT_DIR,
+        help=f"Directory to write files into (default: {DEFAULT_OUTPUT_DIR})",
+    )
+    args = parser.parse_args()
+
+    setup_logging(log_filename="fetch_from_remote.logs", log_dir="logs")
+    logger = logging.getLogger(__name__)
+
+    # Validate required parameters
+    missing = [name for name, val in [
+        ("--token / INFLUXDB_INIT_ADMIN_TOKEN", args.token),
+        ("--org   / INFLUXDB_INIT_ORG",         args.org),
+        ("--bucket / INFLUXDB_INIT_BUCKET",      args.bucket),
+    ] if not val]
+    if missing:
+        parser.error(
+            "Missing required parameters:\n  " + "\n  ".join(missing) +
+            "\n\nSet them via environment variables or CLI flags."
+        )
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    logger.info(
+        f"Fetching last {args.days} days from {args.url} "
+        f"(bucket={args.bucket}, org={args.org}) → {args.output_dir}/"
+    )
+
+    success = export_prices(
+        path_to_parquet=args.output_dir,
+        days_into_past=args.days,
+        file_format=args.format,
+        bucket=args.bucket,
+        org=args.org,
+        url=args.url,
+        token=args.token,
+    )
+
+    if success:
+        logger.info("Export completed successfully.")
+        print(f"\nFiles written to: {args.output_dir}/")
+    else:
+        logger.error("Export failed – check logs for details.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/Tests/test_backtest_engine.py
+++ b/Tests/test_backtest_engine.py
@@ -1,0 +1,253 @@
+"""Tests for BacktestEngine: enter_market, exit_market, update_portfolio,
+compute_metrics, and the full run() loop with MA crossover signals."""
+
+import pytest
+import numpy as np
+import pandas as pd
+from unittest.mock import MagicMock
+
+
+# ── Minimal DataLoader stand-in ───────────────────────────────────────────────
+
+class _MockDataLoader:
+    """Behaves like DataLoader but uses injected price data (no CSV files)."""
+
+    def __init__(self, pair: str, prices: np.ndarray):
+        dates = pd.date_range("2025-01-01", periods=len(prices), freq="1min")
+        self.ticker_current = pd.DataFrame({pair: prices}, index=dates)
+        self.ticker_ask     = pd.DataFrame({pair: prices * 1.001}, index=dates)
+        self.ticker_bid     = pd.DataFrame({pair: prices * 0.999}, index=dates)
+        self.rolling_current_short = None
+        self.rolling_current_long  = None
+
+    def load_csv_export(self):
+        pass  # data already set
+
+    def compute_rolling_means(self, window_short: int, window_long: int):
+        self.rolling_current_short = self.ticker_current.rolling(
+            f"{window_short}min").mean()
+        self.rolling_current_long = self.ticker_current.rolling(
+            f"{window_long}min").mean()
+
+
+PAIR = "XXBTZEUR"
+BASE = "ZEUR"
+TRADING = "XXBT"
+
+BACKTEST_CONFIG = {
+    "maker_fee":        0.0025,
+    "taker_fee":        0.004,
+    "initial_invest":   1000.0,
+    "base_currency":    BASE,
+    "trading_currency": TRADING,
+}
+
+
+def _make_engine(prices: np.ndarray):
+    from altotrader.backtest.backtest_engine import BacktestEngine
+    loader = _MockDataLoader(PAIR, prices)
+    return BacktestEngine(loader, BACKTEST_CONFIG)
+
+
+# ── enter_market ─────────────────────────────────────────────────────────────
+
+class TestEnterMarket:
+    def test_buys_at_ask_price(self):
+        engine = _make_engine(np.full(5, 40_000.0))
+        row = engine.portfolio_view.iloc[1]
+        engine.enter_market(1, row)
+
+        ask = row[PAIR + "_ask"]
+        fee = 1000.0 * engine.taker_fee
+        expected_amount = (1000.0 - fee) / ask
+
+        assert engine.portfolio_view.at[row.name, TRADING] == pytest.approx(expected_amount)
+        assert engine.portfolio_view.at[row.name, BASE] == pytest.approx(0.0)
+
+    def test_market_position_set_to_in(self):
+        engine = _make_engine(np.full(5, 40_000.0))
+        row = engine.portfolio_view.iloc[1]
+        engine.enter_market(1, row)
+        assert engine.portfolio_view.at[row.name, "market_position"] == "in"
+
+    def test_action_logged_as_buy(self):
+        engine = _make_engine(np.full(5, 40_000.0))
+        row = engine.portfolio_view.iloc[1]
+        engine.enter_market(1, row)
+        assert engine.portfolio_view.at[row.name, "action"] == "buy"
+
+    def test_trade_log_entry_created(self):
+        engine = _make_engine(np.full(5, 40_000.0))
+        row = engine.portfolio_view.iloc[1]
+        engine.enter_market(1, row)
+        assert len(engine.trade_log) == 1
+        assert engine.trade_log[0]["action"] == "buy"
+
+    def test_no_buy_when_base_balance_zero(self):
+        engine = _make_engine(np.full(5, 40_000.0))
+        # drain the first row's balance
+        engine.portfolio_view.at[engine.portfolio_view.index[0], BASE] = 0.0
+        row = engine.portfolio_view.iloc[1]
+        engine.enter_market(1, row)
+        # no trade should have been logged
+        assert len(engine.trade_log) == 0
+
+
+# ── exit_market ──────────────────────────────────────────────────────────────
+
+class TestExitMarket:
+    def _engine_with_open_position(self):
+        engine = _make_engine(np.full(5, 40_000.0))
+        # manually open a position at row 1
+        row1 = engine.portfolio_view.iloc[1]
+        engine.enter_market(1, row1)
+        return engine
+
+    def test_sells_at_bid_price(self):
+        engine = self._engine_with_open_position()
+        row2 = engine.portfolio_view.iloc[2]
+        engine.exit_market(2, row2)
+
+        bid = row2[PAIR + "_bid"]
+        crypto_held = engine.portfolio_view.iloc[1][TRADING]
+        gross = crypto_held * bid
+        expected_proceeds = gross * (1 - engine.maker_fee)
+
+        assert engine.portfolio_view.at[row2.name, BASE] == pytest.approx(expected_proceeds)
+        assert engine.portfolio_view.at[row2.name, TRADING] == pytest.approx(0.0)
+
+    def test_market_position_set_to_out(self):
+        engine = self._engine_with_open_position()
+        row2 = engine.portfolio_view.iloc[2]
+        engine.exit_market(2, row2)
+        assert engine.portfolio_view.at[row2.name, "market_position"] == "out"
+
+    def test_trade_log_has_sell_entry(self):
+        engine = self._engine_with_open_position()
+        row2 = engine.portfolio_view.iloc[2]
+        engine.exit_market(2, row2)
+        actions = [t["action"] for t in engine.trade_log]
+        assert "sell" in actions
+
+    def test_no_sell_when_no_position(self):
+        engine = _make_engine(np.full(5, 40_000.0))
+        initial_log_len = len(engine.trade_log)
+        row2 = engine.portfolio_view.iloc[2]
+        engine.exit_market(2, row2)
+        assert len(engine.trade_log) == initial_log_len
+
+
+# ── update_portfolio ─────────────────────────────────────────────────────────
+
+class TestUpdatePortfolio:
+    def test_carries_base_balance_forward(self):
+        engine = _make_engine(np.full(5, 40_000.0))
+        row1 = engine.portfolio_view.iloc[1]
+        engine.update_portfolio(1, row1)
+        assert engine.portfolio_view.at[row1.name, BASE] == pytest.approx(1000.0)
+
+    def test_portfolio_value_reflects_current_price(self):
+        prices = np.full(5, 40_000.0)
+        engine = _make_engine(prices)
+        # open a position first
+        engine.enter_market(1, engine.portfolio_view.iloc[1])
+        row2 = engine.portfolio_view.iloc[2]
+        engine.update_portfolio(2, row2)
+
+        crypto_held = engine.portfolio_view.iloc[1][TRADING]
+        expected_value = crypto_held * prices[2]
+        assert engine.portfolio_view.at[row2.name, f"portfolio_in_{BASE}"] == pytest.approx(expected_value, rel=1e-3)
+
+    def test_returns_early_for_idx_zero(self):
+        engine = _make_engine(np.full(5, 40_000.0))
+        row0 = engine.portfolio_view.iloc[0]
+        # should not raise
+        engine.update_portfolio(0, row0)
+
+
+# ── compute_metrics ──────────────────────────────────────────────────────────
+
+class TestComputeMetrics:
+    def test_no_trades_returns_zero_return(self):
+        engine = _make_engine(np.full(50, 40_000.0))
+        # fill portfolio with constant value (no trades)
+        pv_col = f"portfolio_in_{BASE}"
+        engine.portfolio_view[pv_col] = 1000.0
+        metrics = engine.compute_metrics()
+        assert metrics["total_return_pct"] == pytest.approx(0.0)
+        assert metrics["n_trades"] == 0
+
+    def test_total_return_positive_after_profitable_trade(self):
+        prices = np.full(5, 40_000.0)
+        engine = _make_engine(prices)
+        engine.enter_market(1, engine.portfolio_view.iloc[1])
+        engine.exit_market(2, engine.portfolio_view.iloc[2])
+        engine.update_portfolio(3, engine.portfolio_view.iloc[3])
+        engine.update_portfolio(4, engine.portfolio_view.iloc[4])
+        # No profit expected (same price), but fees should reduce value
+        metrics = engine.compute_metrics()
+        assert metrics["total_return_pct"] < 0  # fees eat into returns at flat price
+        assert metrics["n_trades"] == 1
+
+    def test_win_rate_calculation(self):
+        prices = np.array([40_000.0, 40_000.0, 42_000.0, 42_000.0, 42_000.0])
+        engine = _make_engine(prices)
+        engine.enter_market(1, engine.portfolio_view.iloc[1])
+        engine.exit_market(2, engine.portfolio_view.iloc[2])
+        engine.update_portfolio(3, engine.portfolio_view.iloc[3])
+        engine.update_portfolio(4, engine.portfolio_view.iloc[4])
+        metrics = engine.compute_metrics()
+        assert metrics["win_rate"] == pytest.approx(100.0)
+
+    def test_metrics_keys_present(self):
+        engine = _make_engine(np.full(10, 40_000.0))
+        metrics = engine.compute_metrics()
+        expected_keys = {
+            "total_return_pct", "buy_and_hold_return_pct", "n_trades",
+            "win_rate", "max_drawdown_pct", "sharpe_ratio",
+            "total_fees", "final_portfolio_value",
+        }
+        assert expected_keys.issubset(metrics.keys())
+
+
+# ── run() – MA crossover integration ─────────────────────────────────────────
+
+class TestRun:
+    def _prices_with_crossover(self, n=100):
+        """Flat → dip → recovery: produces one golden cross + one death cross."""
+        p = np.concatenate([
+            np.full(30, 40_000.0),           # flat baseline
+            np.linspace(40_000, 36_000, 20),  # dip  → short MA drops below long
+            np.linspace(36_000, 44_000, 30),  # recovery → golden cross
+            np.linspace(44_000, 38_000, 20),  # decline → death cross
+        ])
+        return p
+
+    def test_run_returns_metrics_dict(self):
+        engine = _make_engine(self._prices_with_crossover())
+        metrics = engine.run(window_short=5, window_long=10)
+        assert isinstance(metrics, dict)
+        assert "total_return_pct" in metrics
+
+    def test_run_resets_state_between_calls(self):
+        engine = _make_engine(self._prices_with_crossover())
+        metrics1 = engine.run(window_short=5, window_long=10)
+        metrics2 = engine.run(window_short=5, window_long=10)
+        assert metrics1["total_return_pct"] == pytest.approx(metrics2["total_return_pct"])
+
+    def test_open_position_force_closed_at_end(self):
+        """If the strategy is 'in' at end of data, a final sell must occur."""
+        # Permanently rising prices → golden cross, never a death cross
+        prices = np.linspace(38_000, 45_000, 80)
+        engine = _make_engine(prices)
+        metrics = engine.run(window_short=5, window_long=10)
+        # Position must be closed; final portfolio should be in base currency
+        final_position = engine.portfolio_view["market_position"].iloc[-1]
+        assert final_position == "out"
+
+    def test_initial_invest_respected(self):
+        prices = np.full(50, 40_000.0)
+        engine = _make_engine(prices)
+        metrics = engine.run(window_short=5, window_long=10)
+        # No crossover on flat prices → no trades → final value = initial
+        assert metrics["final_portfolio_value"] == pytest.approx(1000.0, rel=1e-3)

--- a/Tests/test_dataloader.py
+++ b/Tests/test_dataloader.py
@@ -1,0 +1,154 @@
+"""Tests for DataLoader: CSV loading, NaN interpolation, and rolling means
+for current, ask, and bid price series."""
+
+import pytest
+import numpy as np
+import pandas as pd
+import os
+import tempfile
+
+from altotrader.backtest.dataloader import DataLoader
+
+
+PAIR = "XXBTZEUR"
+N_ROWS = 200  # enough for a long rolling window in tests
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_csv_files(tmp_dir: str, n_rows: int = N_ROWS, pair: str = PAIR,
+                    introduce_nans: bool = False) -> dict:
+    """Write the three CSV files (a, b, c) that DataLoader expects and return
+    the loader_dict pointing at them."""
+
+    dates = pd.date_range("2025-01-01", periods=n_rows, freq="1min")
+    prices = np.linspace(40_000, 42_000, n_rows)
+
+    for suffix, multiplier in [("a", 1.001), ("b", 0.999), ("c", 1.0)]:
+        df = pd.DataFrame(
+            {"ticker_entry": suffix, pair: prices * multiplier},
+            index=dates,
+        )
+        df.index.name = "timestamp"
+        if introduce_nans and suffix == "c":
+            df.iloc[5:8, df.columns.get_loc(pair)] = np.nan
+        filename = f"krakenticker_latest_20d_{suffix}.csv"
+        df.to_csv(os.path.join(tmp_dir, filename))
+
+    return {"export_path": tmp_dir, "latest_days": 20, "logs_dir": tmp_dir}
+
+
+# ── load_csv_export ───────────────────────────────────────────────────────────
+
+class TestLoadCsvExport:
+    def test_loads_all_three_frames(self, tmp_path):
+        config = _make_csv_files(str(tmp_path))
+        loader = DataLoader(config)
+        loader.load_csv_export()
+
+        assert loader.ticker_current is not None
+        assert loader.ticker_ask is not None
+        assert loader.ticker_bid is not None
+
+    def test_frames_have_datetime_index(self, tmp_path):
+        config = _make_csv_files(str(tmp_path))
+        loader = DataLoader(config)
+        loader.load_csv_export()
+
+        assert isinstance(loader.ticker_current.index, pd.DatetimeIndex)
+        assert isinstance(loader.ticker_ask.index, pd.DatetimeIndex)
+        assert isinstance(loader.ticker_bid.index, pd.DatetimeIndex)
+
+    def test_pair_column_present(self, tmp_path):
+        config = _make_csv_files(str(tmp_path))
+        loader = DataLoader(config)
+        loader.load_csv_export()
+
+        assert PAIR in loader.ticker_current.columns
+        assert PAIR in loader.ticker_ask.columns
+        assert PAIR in loader.ticker_bid.columns
+
+    def test_no_nan_after_load(self, tmp_path):
+        config = _make_csv_files(str(tmp_path), introduce_nans=True)
+        loader = DataLoader(config)
+        loader.load_csv_export()
+
+        assert not loader.ticker_current.isna().any().any()
+
+    def test_ask_higher_than_bid(self, tmp_path):
+        config = _make_csv_files(str(tmp_path))
+        loader = DataLoader(config)
+        loader.load_csv_export()
+
+        assert (loader.ticker_ask[PAIR] > loader.ticker_bid[PAIR]).all()
+
+
+# ── compute_rolling_means ─────────────────────────────────────────────────────
+
+class TestComputeRollingMeans:
+    @pytest.fixture
+    def loader(self, tmp_path):
+        config = _make_csv_files(str(tmp_path))
+        dl = DataLoader(config)
+        dl.load_csv_export()
+        return dl
+
+    def test_all_six_rolling_means_computed(self, loader):
+        loader.compute_rolling_means(window_short=10, window_long=50)
+        assert loader.rolling_current_short is not None
+        assert loader.rolling_current_long  is not None
+        assert loader.rolling_ask_short     is not None
+        assert loader.rolling_ask_long      is not None
+        assert loader.rolling_bid_short     is not None
+        assert loader.rolling_bid_long      is not None
+
+    def test_time_based_rolling_has_no_nan(self, loader):
+        # pandas time-based rolling windows (e.g. '10min') do not produce a
+        # warm-up NaN period – every row has at least itself in the window.
+        loader.compute_rolling_means(window_short=10, window_long=50)
+        assert loader.rolling_current_short[PAIR].isna().sum() == 0
+        assert loader.rolling_current_long[PAIR].isna().sum() == 0
+
+    def test_window_properties_set(self, loader):
+        loader.compute_rolling_means(window_short=15, window_long=60)
+        assert loader.window_short == 15
+        assert loader.window_long  == 60
+
+    def test_short_ma_smoother_than_raw(self, loader):
+        loader.compute_rolling_means(window_short=20, window_long=100)
+        raw_std = loader.ticker_current[PAIR].std()
+        ma_std  = loader.rolling_current_short[PAIR].dropna().std()
+        assert ma_std < raw_std
+
+    def test_long_ma_smoother_than_short_ma(self, loader):
+        loader.compute_rolling_means(window_short=10, window_long=60)
+        short_std = loader.rolling_current_short[PAIR].dropna().std()
+        long_std  = loader.rolling_current_long[PAIR].dropna().std()
+        assert long_std <= short_std
+
+
+# ── _iterpolate_nan ───────────────────────────────────────────────────────────
+
+class TestInterpolateNan:
+    def test_interpolates_missing_values(self, tmp_path):
+        config = _make_csv_files(str(tmp_path))
+        loader = DataLoader(config)
+
+        dates = pd.date_range("2025-01-01", periods=10, freq="1min")
+        values = pd.Series([1.0, np.nan, np.nan, 4.0, 5.0,
+                            6.0, 7.0, 8.0, 9.0, 10.0], index=dates)
+        df = pd.DataFrame({"price": values})
+
+        result = loader._iterpolate_nan(df)
+        assert not result.isna().any().any()
+
+    def test_no_change_when_no_nans(self, tmp_path):
+        config = _make_csv_files(str(tmp_path))
+        loader = DataLoader(config)
+
+        dates = pd.date_range("2025-01-01", periods=5, freq="1min")
+        df = pd.DataFrame({"price": [1.0, 2.0, 3.0, 4.0, 5.0]}, index=dates)
+        original = df.copy()
+
+        result = loader._iterpolate_nan(df)
+        pd.testing.assert_frame_equal(result, original)

--- a/Tests/test_update_service.py
+++ b/Tests/test_update_service.py
@@ -1,0 +1,181 @@
+"""Tests for TickerUpdateService: retry logic, config validation,
+and the write pipeline."""
+
+import pytest
+import time
+from unittest.mock import MagicMock, patch, call
+import pandas as pd
+from influxdb_client.client.exceptions import InfluxDBError
+
+from altotrader.database.update_service import TickerUpdateService, _MAX_RETRIES, _RETRY_BASE_DELAY
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+def _make_service():
+    """Return a TickerUpdateService wired to a mock KrakenTicker."""
+    ticker = MagicMock()
+    ticker.get_market_query.return_value = {"XXBTZEUR": {"c": [40000.0]}}
+    ticker.get_last_ticker.return_value = pd.DataFrame(
+        {"XXBTZEUR": [40000.0]},
+        index=pd.to_datetime(["2025-01-01 00:00:00"])
+    )
+    service = TickerUpdateService(ticker, log_dir="logs")
+    return service
+
+
+_VALID_CONFIG = {
+    "bucket": "kraken",
+    "org":    "testorg",
+    "url":    "http://localhost:8086",
+    "token":  "testtoken",
+}
+
+
+# ── _fetch_market_query_with_retry ────────────────────────────────────────────
+
+class TestFetchMarketQueryWithRetry:
+    def test_returns_result_on_first_success(self):
+        service = _make_service()
+        result = service._fetch_market_query_with_retry()
+        assert result == {"XXBTZEUR": {"c": [40000.0]}}
+        assert service.ticker.get_market_query.call_count == 1
+
+    def test_retries_on_empty_result(self):
+        service = _make_service()
+        service.ticker.get_market_query.side_effect = [
+            {},           # fail
+            {},           # fail
+            {"XXBTZEUR": {"c": [40000.0]}},  # success
+        ]
+        with patch("altotrader.database.update_service.time.sleep"):
+            result = service._fetch_market_query_with_retry()
+        assert result == {"XXBTZEUR": {"c": [40000.0]}}
+        assert service.ticker.get_market_query.call_count == 3
+
+    def test_returns_empty_dict_after_all_retries_fail(self):
+        service = _make_service()
+        service.ticker.get_market_query.return_value = {}
+        with patch("altotrader.database.update_service.time.sleep"):
+            result = service._fetch_market_query_with_retry()
+        assert result == {}
+        assert service.ticker.get_market_query.call_count == _MAX_RETRIES
+
+    def test_sleep_duration_doubles(self):
+        service = _make_service()
+        service.ticker.get_market_query.return_value = {}
+        sleep_calls = []
+
+        with patch("altotrader.database.update_service.time.sleep",
+                   side_effect=lambda s: sleep_calls.append(s)):
+            service._fetch_market_query_with_retry()
+
+        # Sleeps: 2, 4, 8  (between 4 attempts = 3 sleeps)
+        assert sleep_calls == [
+            _RETRY_BASE_DELAY * (2 ** i) for i in range(_MAX_RETRIES - 1)
+        ]
+
+
+# ── _write_points / _write_points_with_retry ─────────────────────────────────
+
+class TestWritePoints:
+    def test_returns_false_for_empty_points(self):
+        service = _make_service()
+        result = service._write_points([], _VALID_CONFIG)
+        assert result is False
+
+    def test_returns_false_on_influx_error(self):
+        service = _make_service()
+        with patch("altotrader.database.update_service.InfluxDBClient") as MockClient:
+            mock_ctx = MagicMock()
+            MockClient.return_value.__enter__ = MagicMock(return_value=mock_ctx)
+            MockClient.return_value.__exit__ = MagicMock(return_value=False)
+            mock_ctx.write_api.return_value.write.side_effect = InfluxDBError(
+                message="test error"
+            )
+            from influxdb_client import Point
+            pts = [Point("kraken").field("price", 1.0)]
+            result = service._write_points(pts, _VALID_CONFIG)
+        assert result is False
+
+    def test_returns_false_on_connection_error(self):
+        service = _make_service()
+        with patch("altotrader.database.update_service.InfluxDBClient") as MockClient:
+            MockClient.side_effect = ConnectionError("refused")
+            from influxdb_client import Point
+            pts = [Point("kraken").field("price", 1.0)]
+            result = service._write_points(pts, _VALID_CONFIG)
+        assert result is False
+
+
+class TestWritePointsWithRetry:
+    def test_succeeds_on_first_attempt(self):
+        service = _make_service()
+        service._write_points = MagicMock(return_value=True)
+        result = service._write_points_with_retry(["pt"], _VALID_CONFIG)
+        assert result is True
+        assert service._write_points.call_count == 1
+
+    def test_retries_on_failure(self):
+        service = _make_service()
+        service._write_points = MagicMock(side_effect=[False, False, True])
+        with patch("altotrader.database.update_service.time.sleep"):
+            result = service._write_points_with_retry(["pt"], _VALID_CONFIG)
+        assert result is True
+        assert service._write_points.call_count == 3
+
+    def test_returns_false_after_all_retries_fail(self):
+        service = _make_service()
+        service._write_points = MagicMock(return_value=False)
+        with patch("altotrader.database.update_service.time.sleep"):
+            result = service._write_points_with_retry(["pt"], _VALID_CONFIG)
+        assert result is False
+        assert service._write_points.call_count == _MAX_RETRIES
+
+
+# ── update_pairs_ticker ───────────────────────────────────────────────────────
+
+class TestUpdatePairsTicker:
+    def test_returns_false_on_missing_config(self):
+        service = _make_service()
+        # No env vars set, no explicit args → config values are None
+        result = service.update_pairs_ticker(
+            bucket=None, org=None, url=None, token=None
+        )
+        assert result is False
+
+    def test_returns_false_when_market_query_empty(self):
+        service = _make_service()
+        service.ticker.get_market_query.return_value = {}
+        with patch("altotrader.database.update_service.time.sleep"):
+            result = service.update_pairs_ticker(
+                bucket="b", org="o", url="http://localhost:8086", token="t"
+            )
+        assert result is False
+
+    def test_returns_false_when_ticker_data_empty(self):
+        service = _make_service()
+        service.ticker.get_last_ticker.return_value = pd.DataFrame()
+        with patch("altotrader.database.update_service.time.sleep"), \
+             patch.object(service, "_write_points_with_retry", return_value=True):
+            result = service.update_pairs_ticker(
+                bucket="b", org="o", url="http://localhost:8086", token="t"
+            )
+        assert result is False
+
+    def test_calls_write_with_points_for_all_entries(self):
+        service = _make_service()
+        written_calls = []
+
+        def fake_write(points, config):
+            written_calls.append(len(points))
+            return True
+
+        with patch.object(service, "_write_points_with_retry", side_effect=fake_write):
+            result = service.update_pairs_ticker(
+                bucket="b", org="o", url="http://localhost:8086", token="t"
+            )
+
+        assert result is True
+        # 3 ticker entries (a, b, c) × 1 pair × 1 timestamp = 3 points total
+        assert sum(written_calls) == 3

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,14 @@
+"""Root conftest.py – makes the src/ layout importable and stubs out
+krakenex (which requires a legacy build chain not available in all envs)."""
+
+import sys
+import os
+from unittest.mock import MagicMock
+
+# Add src/ to the path so altotrader is importable without `pip install`
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
+
+# krakenex uses an old setup.py that may fail to build.  Since no test
+# exercises the real network calls, a MagicMock is sufficient.
+if "krakenex" not in sys.modules:
+    sys.modules["krakenex"] = MagicMock()

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,5 @@
 """Root conftest.py – makes the src/ layout importable and stubs out
-krakenex (which requires a legacy build chain not available in all envs)."""
+krakenex only when it cannot be installed (legacy setup.py build issue)."""
 
 import sys
 import os
@@ -8,7 +8,10 @@ from unittest.mock import MagicMock
 # Add src/ to the path so altotrader is importable without `pip install`
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
 
-# krakenex uses an old setup.py that may fail to build.  Since no test
-# exercises the real network calls, a MagicMock is sufficient.
-if "krakenex" not in sys.modules:
+# Only mock krakenex if it genuinely cannot be imported (e.g. build env
+# without legacy setuptools).  In CI where it is installed, the real package
+# is used so that test_krakenticker.py keeps working with patch.object.
+try:
+    import krakenex  # noqa: F401
+except Exception:
     sys.modules["krakenex"] = MagicMock()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,50 @@
+services:
+
+  # ── InfluxDB time-series database ────────────────────────────────────────────
+  influxdb:
+    image: influxdb:2.7
+    container_name: altotrader_influxdb
+    restart: unless-stopped
+    ports:
+      - "8086:8086"      # InfluxDB UI (http://<hetzner-ip>:8086) + API
+    environment:
+      # First-run auto-setup: only applied when the DB is uninitialized.
+      # Values come from the .env file in the project root.
+      DOCKER_INFLUXDB_INIT_MODE:         ${INFLUXDB_INIT_MODE:-setup}
+      DOCKER_INFLUXDB_INIT_USERNAME:     ${INFLUXDB_INIT_USERNAME}
+      DOCKER_INFLUXDB_INIT_PASSWORD:     ${INFLUXDB_INIT_PASSWORD}
+      DOCKER_INFLUXDB_INIT_ORG:          ${INFLUXDB_INIT_ORG}
+      DOCKER_INFLUXDB_INIT_BUCKET:       ${INFLUXDB_INIT_BUCKET}
+      DOCKER_INFLUXDB_INIT_ADMIN_TOKEN:  ${INFLUXDB_INIT_ADMIN_TOKEN}
+    volumes:
+      - influxdb_data:/var/lib/influxdb2      # persistent time-series data
+      - influxdb_config:/etc/influxdb2        # persistent config / tokens
+    healthcheck:
+      test: ["CMD", "influx", "ping"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+  # ── AltoTrader Kraken streamer ────────────────────────────────────────────────
+  altotrader:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: altotrader:latest
+    container_name: altotrader_streamer
+    restart: unless-stopped
+    depends_on:
+      influxdb:
+        condition: service_healthy   # wait until InfluxDB passes its health check
+    environment:
+      INFLUXDB_INIT_BUCKET:       ${INFLUXDB_INIT_BUCKET}
+      INFLUXDB_INIT_ORG:          ${INFLUXDB_INIT_ORG}
+      INFLUXDB_INIT_ADMIN_TOKEN:  ${INFLUXDB_INIT_ADMIN_TOKEN}
+      # Always use the Docker-internal hostname, never localhost
+      INFLUX_URL:                 http://influxdb:8086
+
+# ── Named volumes ─────────────────────────────────────────────────────────────
+volumes:
+  influxdb_data:
+  influxdb_config:

--- a/env/.env.example
+++ b/env/.env.example
@@ -1,0 +1,23 @@
+# ────────────────────────────────────────────────────────────────────
+# AltoTrader – Hetzner environment template
+#
+# 1. Copy this file to .env in the project root:
+#      cp env/.env.example .env
+# 2. Fill in every XX placeholder
+# 3. Never commit .env  (it is git-ignored)
+# ────────────────────────────────────────────────────────────────────
+
+# ── InfluxDB init (applied once on first startup) ───────────────────
+INFLUXDB_INIT_MODE=setup
+INFLUXDB_INIT_USERNAME=admin
+INFLUXDB_INIT_PASSWORD=XX_choose_a_strong_password
+INFLUXDB_INIT_ORG=XX_your_org_name
+INFLUXDB_INIT_BUCKET=kraken
+INFLUXDB_INIT_ADMIN_TOKEN=XX_choose_a_long_random_token
+
+# ── InfluxDB connection (used by the streamer & export scripts) ──────
+# On Hetzner (outside Docker) point to your server IP:
+#   INFLUX_URL=http://<your-hetzner-ip>:8086
+# Inside Docker Compose this is overridden automatically to:
+#   INFLUX_URL=http://influxdb:8086
+INFLUX_URL=http://localhost:8086


### PR DESCRIPTION
## Summary

### Backtesting
- **`BacktestEngine`** vollständig implementiert: `enter_market()` (kauft zum ask-Preis, zieht Taker-Fee ab), `exit_market()` (verkauft zum bid-Preis, zieht Maker-Fee ab), `update_portfolio()` (Balance carry-forward + Portfolio-Wert)
- **`run(window_short, window_long)`**: MA Golden/Death Cross Signale, Force-Close offener Position am Ende
- **`compute_metrics()`**: Total Return %, Buy & Hold Vergleich, Win Rate, Max Drawdown, Sharpe Ratio, Total Fees
- **`DataLoader`**: Rolling Means für ask und bid aktiviert (waren auskommentiert); Null-Check-Bug gefixt (`df.all() is None` → `is None`)

### Data Streaming
- **`TickerUpdateService`**: Retry-Logik mit exponentiellem Backoff (2/4/8/16s, 4 Versuche) für Kraken-Fetch und InfluxDB-Write; `ConnectionError`/`TimeoutError` korrekt abgefangen
- **`run_update_service.py`**: Robuster Polling-Loop mit Back-off bei aufeinanderfolgenden Fehlern, Heartbeat-Logging alle 10 Zyklen, sauberer SIGINT/SIGTERM Shutdown

### Docker / Hetzner
- **`Dockerfile`**: Produktions-Image (`python:3.11-slim`), installiert das Paket via `pip install .`
- **`docker-compose.yml`**: `influxdb:2.7` (Port 8086 für Dashboard) + `altotrader_streamer`; named Volumes für persistente Datenspeicherung; Health-Check verhindert Start vor InfluxDB-Readiness; `INFLUX_URL` automatisch auf internen Docker-Hostname gesetzt
- **`env/.env.example`**: Vorlage mit allen benötigten Variablen und Kommentaren
- **`Examples/fetch_from_remote.py`**: CLI-Script zum lokalen Abziehen von Daten vom Hetzner-Server

### Tests
- **46 neue Tests** (alle grün): `test_backtest_engine.py` (20), `test_dataloader.py` (12), `test_update_service.py` (14)
- **`conftest.py`**: Macht `src/` ohne `pip install` importierbar, stubbt `krakenex` für Environments ohne Legacy-Build-Chain

## Test plan
- [ ] `python -m pytest` – alle 46 Tests grün
- [ ] `docker compose up --build` auf Hetzner-Server starten
- [ ] InfluxDB-Dashboard unter `http://<hetzner-ip>:8086` erreichbar
- [ ] Daten lokal abziehen: `python Examples/fetch_from_remote.py --url http://<hetzner-ip>:8086 ...`
- [ ] Backtest manuell ausführen: `python src/altotrader/backtest/backtest_engine.py`

https://claude.ai/code/session_01HQU7KNPmCQP8eZm9DcY7cf