### PR TITLE
Einheitliches Pair-Format (BTC-EUR) für alle Exchanges

### DIFF
--- a/Examples/binance_pairs.yaml
+++ b/Examples/binance_pairs.yaml
@@ -1,6 +1,6 @@
 items:
-  - BTCEUR
-  - ETHEUR
-  - ETHBTC
-  - SOLUSDT
-  - ADABTC
+  - BTC-EUR
+  - ETH-EUR
+  - ETH-BTC
+  - SOL-USDT
+  - ADA-BTC

--- a/Examples/gemini_pairs.yaml
+++ b/Examples/gemini_pairs.yaml
@@ -1,5 +1,5 @@
 items:
-  - btceur
-  - ethusd
-  - ethbtc
-  - solusd
+  - BTC-EUR
+  - ETH-USD
+  - ETH-BTC
+  - SOL-USD

--- a/Examples/kraken_pairs.yaml
+++ b/Examples/kraken_pairs.yaml
@@ -1,10 +1,9 @@
 items:
-  - XETHZEUR
-  - XXBTZEUR
-  - XETHXXBT
-  - SOLXBT
-  - ADAXBT
-  - LINKXBT
-  - XXRPXXBT
-  - DOTXBT
-  
+  - ETH-EUR
+  - BTC-EUR
+  - ETH-BTC
+  - SOL-BTC
+  - ADA-BTC
+  - LINK-BTC
+  - XRP-BTC
+  - DOT-BTC

--- a/Examples/mexc_pairs.yaml
+++ b/Examples/mexc_pairs.yaml
@@ -1,6 +1,6 @@
 items:
-  - BTCUSDT
-  - ETHUSDT
-  - ETHBTC
-  - SOLUSDT
-  - ADAUSDT
+  - BTC-USDT
+  - ETH-USDT
+  - ETH-BTC
+  - SOL-USDT
+  - ADA-USDT

--- a/Tests/mock_data/mock_pairs.yaml
+++ b/Tests/mock_data/mock_pairs.yaml
@@ -1,3 +1,3 @@
 items:
-  - XETHZEUR
-  - XXBTZEUR
+  - ETH-EUR
+  - BTC-EUR

--- a/Tests/test_binance_ws_ticker.py
+++ b/Tests/test_binance_ws_ticker.py
@@ -20,7 +20,7 @@ from unittest.mock import MagicMock, patch
 
 MOCK_YAML = os.path.join(os.path.dirname(__file__), "mock_data", "mock_pairs.yaml")
 
-PAIRS = ["BTCEUR", "ETHBTC"]
+PAIRS = ["BTC-EUR", "ETH-BTC"]
 
 
 def _yaml_with_pairs(tmp_path, pairs):
@@ -35,13 +35,19 @@ def _make_ticker(tmp_path, pairs=None):
     return BinanceWsTicker(pairs_yaml=yaml_path)
 
 
-def _ticker_msg(symbol: str, c: str, a: str, b: str) -> str:
-    """Build a valid combined-stream 24hrTicker message."""
+def _ticker_msg(unified_pair: str, c: str, a: str, b: str) -> str:
+    """Build a valid combined-stream 24hrTicker message.
+
+    Accepts the unified pair name (e.g. 'BTC-EUR') and converts it to the
+    Binance exchange symbol ('BTCEUR') for the 's' field, matching what the
+    real Binance WS API sends.
+    """
+    ex_sym = unified_pair.replace("-", "")   # BTC-EUR → BTCEUR
     return json.dumps({
-        "stream": f"{symbol.lower()}@ticker",
+        "stream": f"{ex_sym.lower()}@ticker",
         "data": {
             "e": "24hrTicker",
-            "s": symbol,
+            "s": ex_sym,   # Binance always sends uppercase, no-hyphen
             "c": c,
             "a": a,
             "b": b,
@@ -61,23 +67,23 @@ def test_get_market_query_empty_before_start(tmp_path):
 class TestOnMessageValid:
     def test_single_pair_stored(self, tmp_path):
         ticker = _make_ticker(tmp_path)
-        ticker._on_message(None, _ticker_msg("BTCEUR", "60000", "60010", "59990"))
-        assert "BTCEUR" in ticker._prices
-        assert ticker._prices["BTCEUR"]["c"] == pytest.approx(60000.0)
-        assert ticker._prices["BTCEUR"]["a"] == pytest.approx(60010.0)
-        assert ticker._prices["BTCEUR"]["b"] == pytest.approx(59990.0)
+        ticker._on_message(None, _ticker_msg("BTC-EUR", "60000", "60010", "59990"))
+        assert "BTC-EUR" in ticker._prices
+        assert ticker._prices["BTC-EUR"]["c"] == pytest.approx(60000.0)
+        assert ticker._prices["BTC-EUR"]["a"] == pytest.approx(60010.0)
+        assert ticker._prices["BTC-EUR"]["b"] == pytest.approx(59990.0)
 
     def test_two_pairs_stored_independently(self, tmp_path):
         ticker = _make_ticker(tmp_path)
-        ticker._on_message(None, _ticker_msg("BTCEUR", "60000", "60010", "59990"))
-        ticker._on_message(None, _ticker_msg("ETHBTC", "0.050", "0.0501", "0.0499"))
-        assert set(ticker._prices.keys()) == {"BTCEUR", "ETHBTC"}
+        ticker._on_message(None, _ticker_msg("BTC-EUR", "60000", "60010", "59990"))
+        ticker._on_message(None, _ticker_msg("ETH-BTC", "0.050", "0.0501", "0.0499"))
+        assert set(ticker._prices.keys()) == {"BTC-EUR", "ETH-BTC"}
 
     def test_price_updated_on_second_message(self, tmp_path):
         ticker = _make_ticker(tmp_path)
-        ticker._on_message(None, _ticker_msg("BTCEUR", "60000", "60010", "59990"))
-        ticker._on_message(None, _ticker_msg("BTCEUR", "61000", "61010", "60990"))
-        assert ticker._prices["BTCEUR"]["c"] == pytest.approx(61000.0)
+        ticker._on_message(None, _ticker_msg("BTC-EUR", "60000", "60010", "59990"))
+        ticker._on_message(None, _ticker_msg("BTC-EUR", "61000", "61010", "60990"))
+        assert ticker._prices["BTC-EUR"]["c"] == pytest.approx(61000.0)
 
 
 # ── _on_message – sanity/validation checks ────────────────────────────────────
@@ -85,14 +91,16 @@ class TestOnMessageValid:
 class TestOnMessageValidation:
     def test_unknown_symbol_ignored(self, tmp_path):
         ticker = _make_ticker(tmp_path)
-        ticker._on_message(None, _ticker_msg("XYZABC", "100", "101", "99"))
+        ticker._on_message(None, _ticker_msg("XYZ-ABC", "100", "101", "99"))
+        # Neither the unified nor the exchange-format key should be stored
+        assert "XYZ-ABC" not in ticker._prices
         assert "XYZABC" not in ticker._prices
 
     def test_wrong_event_type_ignored(self, tmp_path):
         ticker = _make_ticker(tmp_path)
         msg = json.dumps({
             "stream": "btceur@kline",
-            "data": {"e": "kline", "s": "BTCEUR", "c": "60000", "a": "60010", "b": "59990"},
+            "data": {"e": "kline", "s": "BTC-EUR", "c": "60000", "a": "60010", "b": "59990"},
         })
         ticker._on_message(None, msg)
         assert ticker._prices == {}
@@ -104,19 +112,19 @@ class TestOnMessageValidation:
 
     def test_non_positive_price_skipped(self, tmp_path):
         ticker = _make_ticker(tmp_path)
-        ticker._on_message(None, _ticker_msg("BTCEUR", "0", "60010", "59990"))
-        assert "BTCEUR" not in ticker._prices
+        ticker._on_message(None, _ticker_msg("BTC-EUR", "0", "60010", "59990"))
+        assert "BTC-EUR" not in ticker._prices
 
     def test_negative_price_skipped(self, tmp_path):
         ticker = _make_ticker(tmp_path)
-        ticker._on_message(None, _ticker_msg("BTCEUR", "60000", "-1", "59990"))
-        assert "BTCEUR" not in ticker._prices
+        ticker._on_message(None, _ticker_msg("BTC-EUR", "60000", "-1", "59990"))
+        assert "BTC-EUR" not in ticker._prices
 
     def test_crossed_market_skipped(self, tmp_path):
         """ask < bid is a crossed market – must be rejected."""
         ticker = _make_ticker(tmp_path)
-        ticker._on_message(None, _ticker_msg("BTCEUR", "60000", "59900", "60100"))
-        assert "BTCEUR" not in ticker._prices
+        ticker._on_message(None, _ticker_msg("BTC-EUR", "60000", "59900", "60100"))
+        assert "BTC-EUR" not in ticker._prices
 
     def test_malformed_json_does_not_raise(self, tmp_path):
         ticker = _make_ticker(tmp_path)
@@ -127,10 +135,10 @@ class TestOnMessageValidation:
         ticker = _make_ticker(tmp_path)
         msg = json.dumps({
             "stream": "btceur@ticker",
-            "data": {"e": "24hrTicker", "s": "BTCEUR", "c": "60000"},  # missing a, b
+            "data": {"e": "24hrTicker", "s": "BTC-EUR", "c": "60000"},  # missing a, b
         })
         ticker._on_message(None, msg)
-        assert "BTCEUR" not in ticker._prices
+        assert "BTC-EUR" not in ticker._prices
 
 
 # ── get_market_query after data ───────────────────────────────────────────────
@@ -138,22 +146,22 @@ class TestOnMessageValidation:
 class TestGetMarketQuery:
     def test_returns_snapshot_with_both_pairs(self, tmp_path):
         ticker = _make_ticker(tmp_path)
-        ticker._on_message(None, _ticker_msg("BTCEUR", "60000", "60010", "59990"))
-        ticker._on_message(None, _ticker_msg("ETHBTC", "0.050", "0.0501", "0.0499"))
+        ticker._on_message(None, _ticker_msg("BTC-EUR", "60000", "60010", "59990"))
+        ticker._on_message(None, _ticker_msg("ETH-BTC", "0.050", "0.0501", "0.0499"))
         mq = ticker.get_market_query()
-        assert set(mq.keys()) == {"BTCEUR", "ETHBTC"}
+        assert set(mq.keys()) == {"BTC-EUR", "ETH-BTC"}
 
     def test_snapshot_is_a_copy(self, tmp_path):
         """Modifying the returned dict must not affect the internal cache."""
         ticker = _make_ticker(tmp_path)
-        ticker._on_message(None, _ticker_msg("BTCEUR", "60000", "60010", "59990"))
+        ticker._on_message(None, _ticker_msg("BTC-EUR", "60000", "60010", "59990"))
         mq = ticker.get_market_query()
-        mq["BTCEUR"]["c"] = 0.0
-        assert ticker._prices["BTCEUR"]["c"] == pytest.approx(60000.0)
+        mq["BTC-EUR"]["c"] = 0.0
+        assert ticker._prices["BTC-EUR"]["c"] == pytest.approx(60000.0)
 
     def test_timestamp_set_after_query(self, tmp_path):
         ticker = _make_ticker(tmp_path)
-        ticker._on_message(None, _ticker_msg("BTCEUR", "60000", "60010", "59990"))
+        ticker._on_message(None, _ticker_msg("BTC-EUR", "60000", "60010", "59990"))
         ticker.get_market_query()
         assert ticker.timestamp_last_fetch is not None
 
@@ -163,25 +171,25 @@ class TestGetMarketQuery:
 class TestGetLastTicker:
     def _ticker_with_data(self, tmp_path):
         t = _make_ticker(tmp_path)
-        t._on_message(None, _ticker_msg("BTCEUR", "60000", "60010", "59990"))
-        t._on_message(None, _ticker_msg("ETHBTC", "0.050", "0.0501", "0.0499"))
+        t._on_message(None, _ticker_msg("BTC-EUR", "60000", "60010", "59990"))
+        t._on_message(None, _ticker_msg("ETH-BTC", "0.050", "0.0501", "0.0499"))
         return t
 
     def test_close_price(self, tmp_path):
         ticker = self._ticker_with_data(tmp_path)
         df = ticker.get_last_ticker("c")
         assert isinstance(df, pd.DataFrame)
-        assert df["BTCEUR"].iloc[0] == pytest.approx(60000.0)
+        assert df["BTC-EUR"].iloc[0] == pytest.approx(60000.0)
 
     def test_ask_price(self, tmp_path):
         ticker = self._ticker_with_data(tmp_path)
         df = ticker.get_last_ticker("a")
-        assert df["BTCEUR"].iloc[0] == pytest.approx(60010.0)
+        assert df["BTC-EUR"].iloc[0] == pytest.approx(60010.0)
 
     def test_bid_price(self, tmp_path):
         ticker = self._ticker_with_data(tmp_path)
         df = ticker.get_last_ticker("b")
-        assert df["BTCEUR"].iloc[0] == pytest.approx(59990.0)
+        assert df["BTC-EUR"].iloc[0] == pytest.approx(59990.0)
 
     def test_shape(self, tmp_path):
         ticker = self._ticker_with_data(tmp_path)
@@ -208,14 +216,14 @@ def test_reconnect_triggered_when_session_too_old(tmp_path):
     mock_ws = MagicMock()
     # Pretend we've been connected for longer than the session limit
     ticker._connected_at = time.monotonic() - _MAX_SESSION_SEC - 1
-    ticker._on_message(mock_ws, _ticker_msg("BTCEUR", "60000", "60010", "59990"))
+    ticker._on_message(mock_ws, _ticker_msg("BTC-EUR", "60000", "60010", "59990"))
     mock_ws.close.assert_called_once()
 
 
 # ── WS URL construction ───────────────────────────────────────────────────────
 
 def test_ws_url_contains_all_streams(tmp_path):
-    ticker = _make_ticker(tmp_path, ["BTCEUR", "ETHBTC"])
+    ticker = _make_ticker(tmp_path, ["BTC-EUR", "ETH-BTC"])
     url = ticker._ws_url()
     assert "btceur@ticker" in url
     assert "ethbtc@ticker" in url
@@ -234,7 +242,7 @@ def test_concurrent_writes_do_not_raise(tmp_path):
             try:
                 ticker._on_message(
                     None,
-                    _ticker_msg("BTCEUR", "60000", "60010", "59990"),
+                    _ticker_msg("BTC-EUR", "60000", "60010", "59990"),
                 )
             except Exception as exc:
                 errors.append(exc)

--- a/Tests/test_exchange_tickers.py
+++ b/Tests/test_exchange_tickers.py
@@ -2,11 +2,14 @@
 
 All HTTP calls are mocked with unittest.mock so no real network access is
 needed.  The test suite verifies:
-  - get_market_query() returns the normalised {pair: {c, a, b}} dict
+  - get_market_query() returns the normalised {unified_pair: {c, a, b}} dict
   - get_last_ticker() returns a correctly shaped DataFrame for c / a / b
   - Invalid ticker_entry raises ValueError
   - HTTP errors (non-200) result in an empty dict / empty DataFrame
   - Partial failures (one pair missing) are handled gracefully
+
+Pair format: all tickers use the unified 'BTC-EUR' convention in their YAML
+files.  Each ticker converts internally to the exchange-specific symbol.
 """
 from __future__ import annotations
 
@@ -15,31 +18,22 @@ import pytest
 import pandas as pd
 from unittest.mock import patch, MagicMock
 
-
-# ── Helpers ───────────────────────────────────────────────────────────────────
-
 MOCK_YAML = os.path.join(os.path.dirname(__file__), "mock_data", "mock_pairs.yaml")
 
-# Pair names used across the tests (must match mock_pairs.yaml)
-PAIR1 = "XETHZEUR"
-PAIR2 = "XXBTZEUR"
-
-# Exchange-specific pair sets
-BINANCE_PAIRS   = ["BTCEUR", "ETHBTC"]
+# Unified pair names (used in YAML and returned by get_market_query)
+BINANCE_PAIRS   = ["BTC-EUR", "ETH-BTC"]
 COINBASE_PAIRS  = ["BTC-EUR", "ETH-BTC"]
-GEMINI_PAIRS    = ["btceur", "ethbtc"]
-MEXC_PAIRS      = ["BTCUSDT", "ETHBTC"]
+GEMINI_PAIRS    = ["BTC-EUR", "ETH-BTC"]
+MEXC_PAIRS      = ["BTC-USDT", "ETH-BTC"]
 
 
 def _yaml_with_pairs(tmp_path, pairs: list) -> str:
-    """Write a temporary YAML file and return its path."""
     p = tmp_path / "pairs.yaml"
     p.write_text("items:\n" + "".join(f"  - {x}\n" for x in pairs))
     return str(p)
 
 
 def _mock_response(json_data, status_code: int = 200):
-    """Build a mock requests.Response."""
     m = MagicMock()
     m.status_code = status_code
     m.json.return_value = json_data
@@ -57,23 +51,24 @@ def _mock_response(json_data, status_code: int = 200):
 class TestBinanceTicker:
     def _make(self, tmp_path):
         from altotrader.ticker.binanceticker import BinanceTicker
-        yaml_path = _yaml_with_pairs(tmp_path, BINANCE_PAIRS)
-        return BinanceTicker(pairs_yaml=yaml_path)
+        return BinanceTicker(pairs_yaml=_yaml_with_pairs(tmp_path, BINANCE_PAIRS))
 
     def _binance_response(self):
+        # Binance returns uppercase, no-hyphen symbols
         return [
             {"symbol": "BTCEUR", "lastPrice": "60000.00", "askPrice": "60010.00", "bidPrice": "59990.00"},
             {"symbol": "ETHBTC", "lastPrice": "0.050",    "askPrice": "0.0501",    "bidPrice": "0.0499"},
         ]
 
-    def test_get_market_query_returns_normalised_dict(self, tmp_path):
+    def test_get_market_query_keyed_by_unified_pair(self, tmp_path):
         ticker = self._make(tmp_path)
         with patch("requests.get", return_value=_mock_response(self._binance_response())):
             mq = ticker.get_market_query()
+        # Keys must be unified pair names, not exchange symbols
         assert set(mq.keys()) == set(BINANCE_PAIRS)
-        assert mq["BTCEUR"]["c"] == pytest.approx(60000.0)
-        assert mq["BTCEUR"]["a"] == pytest.approx(60010.0)
-        assert mq["BTCEUR"]["b"] == pytest.approx(59990.0)
+        assert mq["BTC-EUR"]["c"] == pytest.approx(60000.0)
+        assert mq["BTC-EUR"]["a"] == pytest.approx(60010.0)
+        assert mq["BTC-EUR"]["b"] == pytest.approx(59990.0)
 
     def test_get_last_ticker_close(self, tmp_path):
         ticker = self._make(tmp_path)
@@ -82,26 +77,26 @@ class TestBinanceTicker:
         df = ticker.get_last_ticker("c", market_query=mq)
         assert isinstance(df, pd.DataFrame)
         assert set(df.columns) == set(BINANCE_PAIRS)
-        assert df["BTCEUR"].iloc[0] == pytest.approx(60000.0)
+        assert df["BTC-EUR"].iloc[0] == pytest.approx(60000.0)
 
     def test_get_last_ticker_ask(self, tmp_path):
         ticker = self._make(tmp_path)
         with patch("requests.get", return_value=_mock_response(self._binance_response())):
             mq = ticker.get_market_query()
         df = ticker.get_last_ticker("a", market_query=mq)
-        assert df["BTCEUR"].iloc[0] == pytest.approx(60010.0)
+        assert df["BTC-EUR"].iloc[0] == pytest.approx(60010.0)
 
     def test_get_last_ticker_bid(self, tmp_path):
         ticker = self._make(tmp_path)
         with patch("requests.get", return_value=_mock_response(self._binance_response())):
             mq = ticker.get_market_query()
         df = ticker.get_last_ticker("b", market_query=mq)
-        assert df["BTCEUR"].iloc[0] == pytest.approx(59990.0)
+        assert df["BTC-EUR"].iloc[0] == pytest.approx(59990.0)
 
     def test_invalid_ticker_entry_raises(self, tmp_path):
         ticker = self._make(tmp_path)
         with pytest.raises(ValueError, match="ticker_entry"):
-            ticker.get_last_ticker("x", market_query={"BTCEUR": {"c": 1, "a": 1, "b": 1}})
+            ticker.get_last_ticker("x", market_query={"BTC-EUR": {"c": 1, "a": 1, "b": 1}})
 
     def test_http_error_returns_empty_dict(self, tmp_path):
         ticker = self._make(tmp_path)
@@ -114,10 +109,9 @@ class TestBinanceTicker:
         ticker = self._make(tmp_path)
         single = {"symbol": "BTCEUR", "lastPrice": "60000.00",
                   "askPrice": "60010.00", "bidPrice": "59990.00"}
-        # Inject ETHBTC from pairs but response only has BTCEUR
         with patch("requests.get", return_value=_mock_response(single)):
             mq = ticker.get_market_query()
-        assert "BTCEUR" in mq
+        assert "BTC-EUR" in mq
 
     def test_timestamp_set_after_fetch(self, tmp_path):
         ticker = self._make(tmp_path)
@@ -133,8 +127,7 @@ class TestBinanceTicker:
 class TestCoinbaseTicker:
     def _make(self, tmp_path):
         from altotrader.ticker.coinbaseticker import CoinbaseTicker
-        yaml_path = _yaml_with_pairs(tmp_path, COINBASE_PAIRS)
-        return CoinbaseTicker(pairs_yaml=yaml_path)
+        return CoinbaseTicker(pairs_yaml=_yaml_with_pairs(tmp_path, COINBASE_PAIRS))
 
     def _response_for(self, pair: str):
         data = {
@@ -155,7 +148,6 @@ class TestCoinbaseTicker:
 
     def test_partial_failure_still_returns_good_pairs(self, tmp_path):
         ticker = self._make(tmp_path)
-        import requests as req
         good  = _mock_response(self._response_for("BTC-EUR"))
         error = _mock_response({}, status_code=503)
         with patch("requests.get", side_effect=[good, error]):
@@ -177,8 +169,7 @@ class TestCoinbaseTicker:
         with patch("requests.get", side_effect=errors):
             mq = ticker.get_market_query()
         assert mq == {}
-        df = ticker.get_last_ticker("c", market_query=mq)
-        assert df.empty
+        assert ticker.get_last_ticker("c", market_query=mq).empty
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -188,42 +179,38 @@ class TestCoinbaseTicker:
 class TestGeminiTicker:
     def _make(self, tmp_path):
         from altotrader.ticker.geminiticker import GeminiTicker
-        yaml_path = _yaml_with_pairs(tmp_path, GEMINI_PAIRS)
-        return GeminiTicker(pairs_yaml=yaml_path)
+        return GeminiTicker(pairs_yaml=_yaml_with_pairs(tmp_path, GEMINI_PAIRS))
 
     def _response_for(self, pair: str):
         data = {
-            "btceur": {"last": "60000.00", "ask": "60010.00", "bid": "59990.00"},
-            "ethbtc": {"last": "0.050",    "ask": "0.0501",   "bid": "0.0499"},
+            "BTC-EUR": {"last": "60000.00", "ask": "60010.00", "bid": "59990.00"},
+            "ETH-BTC": {"last": "0.050",    "ask": "0.0501",   "bid": "0.0499"},
         }
-        return data[pair.lower()]
+        return data[pair]
 
     def test_get_market_query_normalised(self, tmp_path):
         ticker = self._make(tmp_path)
         responses = [_mock_response(self._response_for(p)) for p in GEMINI_PAIRS]
         with patch("requests.get", side_effect=responses):
             mq = ticker.get_market_query()
+        # Keys must be unified names, not Gemini's lowercase
         assert set(mq.keys()) == set(GEMINI_PAIRS)
-        assert mq["btceur"]["c"] == pytest.approx(60000.0)
+        assert mq["BTC-EUR"]["c"] == pytest.approx(60000.0)
 
-    def test_uppercase_pairs_preserved(self, tmp_path):
-        """Pairs defined in YAML as uppercase should remain uppercase as dict keys."""
-        from altotrader.ticker.geminiticker import GeminiTicker
-        yaml_path = _yaml_with_pairs(tmp_path, ["BTCEUR"])
-        ticker = GeminiTicker(pairs_yaml=yaml_path)
-        resp = _mock_response({"last": "60000", "ask": "60010", "bid": "59990"})
-        with patch("requests.get", return_value=resp):
-            mq = ticker.get_market_query()
-        assert "BTCEUR" in mq  # key must match the original YAML spelling
+    def test_to_exchange_pair_converts_to_lowercase(self, tmp_path):
+        """Gemini uses lowercase no-separator symbols internally."""
+        ticker = self._make(tmp_path)
+        assert ticker._to_exchange_pair("BTC-EUR") == "btceur"
+        assert ticker._to_exchange_pair("ETH-BTC") == "ethbtc"
 
     def test_partial_failure(self, tmp_path):
         ticker = self._make(tmp_path)
-        good  = _mock_response(self._response_for("btceur"))
+        good  = _mock_response(self._response_for("BTC-EUR"))
         error = _mock_response({}, status_code=404)
         with patch("requests.get", side_effect=[good, error]):
             mq = ticker.get_market_query()
-        assert "btceur" in mq
-        assert "ethbtc" not in mq
+        assert "BTC-EUR" in mq
+        assert "ETH-BTC" not in mq
 
     def test_get_last_ticker_bid(self, tmp_path):
         ticker = self._make(tmp_path)
@@ -231,7 +218,7 @@ class TestGeminiTicker:
         with patch("requests.get", side_effect=responses):
             mq = ticker.get_market_query()
         df = ticker.get_last_ticker("b", market_query=mq)
-        assert df["btceur"].iloc[0] == pytest.approx(59990.0)
+        assert df["BTC-EUR"].iloc[0] == pytest.approx(59990.0)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -241,56 +228,48 @@ class TestGeminiTicker:
 class TestMEXCTicker:
     def _make(self, tmp_path):
         from altotrader.ticker.mexcticker import MEXCTicker
-        yaml_path = _yaml_with_pairs(tmp_path, MEXC_PAIRS)
-        return MEXCTicker(pairs_yaml=yaml_path)
+        return MEXCTicker(pairs_yaml=_yaml_with_pairs(tmp_path, MEXC_PAIRS))
 
     def _price_response(self):
+        # MEXC returns uppercase, no-hyphen symbols
         return [
-            {"symbol": "BTCUSDT", "price": "60000.00"},
-            {"symbol": "ETHBTC",  "price": "0.050"},
-            {"symbol": "OTHERXYZ", "price": "1.0"},  # should be filtered out
+            {"symbol": "BTCUSDT",  "price": "60000.00"},
+            {"symbol": "ETHBTC",   "price": "0.050"},
+            {"symbol": "OTHERUSD", "price": "1.0"},
         ]
 
     def _book_response(self):
         return [
-            {"symbol": "BTCUSDT", "askPrice": "60010.00", "bidPrice": "59990.00"},
-            {"symbol": "ETHBTC",  "askPrice": "0.0501",   "bidPrice": "0.0499"},
-            {"symbol": "OTHERXYZ", "askPrice": "1.01",    "bidPrice": "0.99"},
+            {"symbol": "BTCUSDT",  "askPrice": "60010.00", "bidPrice": "59990.00"},
+            {"symbol": "ETHBTC",   "askPrice": "0.0501",   "bidPrice": "0.0499"},
+            {"symbol": "OTHERUSD", "askPrice": "1.01",     "bidPrice": "0.99"},
         ]
 
     def test_get_market_query_two_requests(self, tmp_path):
         ticker = self._make(tmp_path)
-        resps = [
-            _mock_response(self._price_response()),
-            _mock_response(self._book_response()),
-        ]
+        resps = [_mock_response(self._price_response()), _mock_response(self._book_response())]
         with patch("requests.get", side_effect=resps) as mock_get:
-            mq = ticker.get_market_query()
-        assert mock_get.call_count == 2  # one for price, one for bookTicker
+            ticker.get_market_query()
+        assert mock_get.call_count == 2
 
-    def test_get_market_query_normalised(self, tmp_path):
+    def test_get_market_query_keyed_by_unified(self, tmp_path):
         ticker = self._make(tmp_path)
-        resps = [
-            _mock_response(self._price_response()),
-            _mock_response(self._book_response()),
-        ]
+        resps = [_mock_response(self._price_response()), _mock_response(self._book_response())]
         with patch("requests.get", side_effect=resps):
             mq = ticker.get_market_query()
+        # Keys must be unified names ("BTC-USDT"), not exchange symbols ("BTCUSDT")
         assert set(mq.keys()) == set(MEXC_PAIRS)
-        assert mq["BTCUSDT"]["c"] == pytest.approx(60000.0)
-        assert mq["BTCUSDT"]["a"] == pytest.approx(60010.0)
-        assert mq["BTCUSDT"]["b"] == pytest.approx(59990.0)
+        assert mq["BTC-USDT"]["c"] == pytest.approx(60000.0)
+        assert mq["BTC-USDT"]["a"] == pytest.approx(60010.0)
+        assert mq["BTC-USDT"]["b"] == pytest.approx(59990.0)
 
     def test_unknown_pair_excluded(self, tmp_path):
-        """OTHERXYZ is in the API response but not in pairs_yaml – must be excluded."""
         ticker = self._make(tmp_path)
-        resps = [
-            _mock_response(self._price_response()),
-            _mock_response(self._book_response()),
-        ]
+        resps = [_mock_response(self._price_response()), _mock_response(self._book_response())]
         with patch("requests.get", side_effect=resps):
             mq = ticker.get_market_query()
-        assert "OTHERXYZ" not in mq
+        assert "OTHERUSD" not in mq
+        assert "OTHER-USD" not in mq
 
     def test_http_error_returns_empty(self, tmp_path):
         ticker = self._make(tmp_path)
@@ -301,21 +280,15 @@ class TestMEXCTicker:
 
     def test_get_last_ticker_ask(self, tmp_path):
         ticker = self._make(tmp_path)
-        resps = [
-            _mock_response(self._price_response()),
-            _mock_response(self._book_response()),
-        ]
+        resps = [_mock_response(self._price_response()), _mock_response(self._book_response())]
         with patch("requests.get", side_effect=resps):
             mq = ticker.get_market_query()
         df = ticker.get_last_ticker("a", market_query=mq)
-        assert df["BTCUSDT"].iloc[0] == pytest.approx(60010.0)
+        assert df["BTC-USDT"].iloc[0] == pytest.approx(60010.0)
 
     def test_timestamp_set(self, tmp_path):
         ticker = self._make(tmp_path)
-        resps = [
-            _mock_response(self._price_response()),
-            _mock_response(self._book_response()),
-        ]
+        resps = [_mock_response(self._price_response()), _mock_response(self._book_response())]
         with patch("requests.get", side_effect=resps):
             ticker.get_market_query()
         assert ticker.timestamp_last_fetch is not None

--- a/Tests/test_krakenticker.py
+++ b/Tests/test_krakenticker.py
@@ -25,64 +25,62 @@ needs_real_krakenex = pytest.mark.skipif(
 
 from altotrader.ticker.krakenticker import KrakenTicker
 
-# Test the _load_yaml method
+# Pairs in the mock YAML use the unified format
+ETH_EUR = "ETH-EUR"
+BTC_EUR = "BTC-EUR"
+
+# Corresponding Kraken REST pair names (for mocking the API response)
+XETHZEUR = "XETHZEUR"
+XXBTZEUR = "XXBTZEUR"
 
 
 def test_load_yaml():
-    # Get the path to the mock_pairs.yaml file located in the Tests/ directory
     test_file_path = os.path.join(os.path.dirname(
         __file__), 'mock_data/mock_pairs.yaml')
 
-    # Instantiate KrakenTicker with the correct path
     ticker = KrakenTicker(test_file_path)
-
-    # Call the load_yaml method directly (it should have been called in __init__)
     pairs = ticker.load_yaml(test_file_path)
 
-    # Verify that the list returned is correct
-    assert pairs == ['XETHZEUR', 'XXBTZEUR']
+    # YAML now uses unified format
+    assert pairs == [ETH_EUR, BTC_EUR]
 
-
-# # Test the get_market_query method with a successful response
 
 @needs_real_krakenex
-@patch.object(krakenex.API, 'query_public', return_value={"result": {"XETHZEUR": {"c": [1743.55]}}})
+@patch.object(krakenex.API, 'query_public',
+              return_value={"result": {"XETHZEUR": {"c": [1743.55]}}})
 def test_get_market_query(mock_query_public):
     test_file_path = os.path.join(os.path.dirname(
         __file__), 'mock_data/mock_pairs.yaml')
     ticker = KrakenTicker(test_file_path)
 
-    # Call the method to get the market query
     market_query = ticker.get_market_query()
 
-    # Assert the response contains the expected data
     assert isinstance(market_query, dict)
-    assert "XETHZEUR" in market_query
-    assert market_query["XETHZEUR"]["c"][0] == 1743.55
-
-# # Test the get_market_price method with a valid response
+    # Result must be keyed by the unified pair name
+    assert ETH_EUR in market_query
+    assert market_query[ETH_EUR]["c"][0] == 1743.55
 
 
 @needs_real_krakenex
-@patch.object(krakenex.API, 'query_public', return_value={"result": {"XETHZEUR": {"c": [1743.55]}, "XXBTZEUR": {"c": [78230.1]}}})
+@patch.object(krakenex.API, 'query_public',
+              return_value={"result": {
+                  "XETHZEUR": {"c": [1743.55], "a": [1744.00], "b": [1743.00]},
+                  "XXBTZEUR": {"c": [78230.1], "a": [78250.0], "b": [78210.0]},
+              }})
 def test_get_market_price_valid(mock_query_public):
     test_file_path = os.path.join(os.path.dirname(
         __file__), 'mock_data/mock_pairs.yaml')
     ticker = KrakenTicker(test_file_path)
 
-    # Call the method to get the market price DataFrame
     df = ticker.get_last_ticker(ticker_entry='c')
 
-    # Assert the returned DataFrame has the expected shape and columns
     assert isinstance(df, pd.DataFrame)
-    assert df.shape == (1, 2)  # 1 row, 2 columns (XETHZEUR and XXBTZEUR)
-    assert 'XETHZEUR' in df.columns
-    assert 'XXBTZEUR' in df.columns
+    assert df.shape == (1, 2)
+    assert ETH_EUR in df.columns
+    assert BTC_EUR in df.columns
     assert abs(df.index[0] - ticker.current_timestamp()) < pd.Timedelta("1s")
-    assert df['XETHZEUR'][0] == 1743.55
-    assert df['XXBTZEUR'][0] == 78230.1
-
-# # Test the get_market_price method when no valid data is returned
+    assert df[ETH_EUR][0] == 1743.55
+    assert df[BTC_EUR][0] == 78230.1
 
 
 @patch.object(krakenex.API, 'query_public', return_value={"result": {}})
@@ -91,22 +89,17 @@ def test_get_market_price_no_data(mock_query_public):
         __file__), 'mock_data/mock_pairs.yaml')
     ticker = KrakenTicker(test_file_path)
 
-    # Call the method to get the market price DataFrame
     df = ticker.get_last_ticker(ticker_entry='c')
 
-    # Assert the returned DataFrame is empty
     assert df.empty
 
 
-# # Test the get_market_price method with an error in the API cal
 @patch.object(krakenex.API, 'query_public', side_effect=Exception("API call failed"))
 def test_get_market_price_error(mock_query_public):
     test_file_path = os.path.join(os.path.dirname(
         __file__), 'mock_data/mock_pairs.yaml')
     ticker = KrakenTicker(test_file_path)
 
-    # Call the method to get the market price DataFrame
     df = ticker.get_last_ticker(ticker_entry='c')
 
-    # Assert the returned DataFrame is empty
     assert df.empty

--- a/src/altotrader/ticker/binance_ws_ticker.py
+++ b/src/altotrader/ticker/binance_ws_ticker.py
@@ -46,9 +46,10 @@ Or as a context manager::
 
 Pair format
 -----------
-Pairs in the YAML file must use Binance's uppercase convention (e.g.
-``BTCEUR``, ``ETHBTC``, ``SOLUSDT``).  The ticker converts them to
-lowercase stream names internally.
+Pairs in the YAML file use the unified hyphen-separated convention (e.g.
+``BTC-EUR``, ``ETH-BTC``, ``SOL-USDT``).  The ticker converts them to
+Binance's exchange symbols (``BTCEUR``) and lowercase stream names
+(``btceur@ticker``) internally.
 """
 from __future__ import annotations
 
@@ -92,8 +93,12 @@ class BinanceWsTicker(RestBaseTicker):
         self._stop_event   = threading.Event()
         self._connected_at: Optional[float] = None  # monotonic time
 
-        # Binance stream names are lowercase (e.g. "btceur@ticker")
-        self._stream_names = [f"{p.lower()}@ticker" for p in self.pairs_list]
+        # Reverse map: exchange symbol (uppercase, no hyphen) → unified pair
+        # e.g. "BTCEUR" → "BTC-EUR"
+        self._ex_to_unified = {p.replace("-", ""): p for p in self.pairs_list}
+
+        # WS stream names are lowercase with no separator (e.g. "btceur@ticker")
+        self._stream_names = [f"{p.replace('-', '').lower()}@ticker" for p in self.pairs_list]
 
         self.logger.info(
             f"BinanceWsTicker initialised | streams: {self._stream_names}"
@@ -221,8 +226,9 @@ class BinanceWsTicker(RestBaseTicker):
             if tick.get("e") != "24hrTicker":
                 return
 
-            symbol = tick.get("s", "")
-            if symbol not in self.pairs_list:
+            ex_symbol = tick.get("s", "")           # e.g. "BTCEUR"
+            symbol    = self._ex_to_unified.get(ex_symbol)  # → "BTC-EUR"
+            if symbol is None:
                 return
 
             # Parse the three price fields

--- a/src/altotrader/ticker/binanceticker.py
+++ b/src/altotrader/ticker/binanceticker.py
@@ -3,8 +3,8 @@
 Uses the public ``/api/v3/ticker/24hr`` endpoint which returns last price,
 ask, and bid for all symbols without authentication.
 
-Pair format: ``BTCEUR``, ``ETHBTC``, ``SOLUSDT`` …
-(Binance spot symbol convention – uppercase, no separator)
+Pair format: ``BTC-EUR``, ``ETH-BTC``, ``SOL-USDT`` …
+(unified hyphen-separated format; converted to ``BTCEUR`` internally)
 """
 from __future__ import annotations
 
@@ -21,16 +21,22 @@ class BinanceTicker(RestBaseTicker):
 
     EXCHANGE = "binance"
 
+    # _to_exchange_pair() inherited default: "BTC-EUR" → "BTCEUR" ✓
+
     def get_market_query(self) -> Dict:
         """Fetch 24-hour ticker stats for all configured pairs.
 
         Returns:
-            Normalised dict ``{symbol: {c, a, b}}``.
+            Normalised dict ``{unified_pair: {c, a, b}}``
+            (e.g. ``{"BTC-EUR": {"c": 60000.0, "a": 60010.0, "b": 59990.0}}``).
         """
         try:
+            exchange_pairs = [self._to_exchange_pair(p) for p in self.pairs_list]
+            reverse        = self._exchange_to_unified_map()  # BTCEUR → BTC-EUR
+
             params: dict = {}
-            if self.pairs_list:
-                params["symbols"] = json.dumps(self.pairs_list)
+            if exchange_pairs:
+                params["symbols"] = json.dumps(exchange_pairs)
 
             data = self._get(f"{_BASE_URL}/ticker/24hr", params=params)
             if isinstance(data, dict):
@@ -38,10 +44,11 @@ class BinanceTicker(RestBaseTicker):
 
             result: Dict = {}
             for item in data:
-                sym = item["symbol"]
-                if sym not in self.pairs_list:
+                ex_sym   = item["symbol"]
+                unified  = reverse.get(ex_sym)
+                if unified is None:
                     continue
-                result[sym] = {
+                result[unified] = {
                     "c": float(item["lastPrice"]),
                     "a": float(item["askPrice"]),
                     "b": float(item["bidPrice"]),

--- a/src/altotrader/ticker/coinbaseticker.py
+++ b/src/altotrader/ticker/coinbaseticker.py
@@ -4,7 +4,7 @@ Uses the public ``/products/{product_id}/ticker`` endpoint – no authentication
 required.  One HTTP request is made per trading pair.
 
 Pair format: ``BTC-EUR``, ``ETH-BTC``, ``SOL-USD`` …
-(Coinbase hyphen-separated convention)
+(Coinbase already uses hyphen-separated pairs, so no conversion is needed)
 """
 from __future__ import annotations
 
@@ -20,11 +20,15 @@ class CoinbaseTicker(RestBaseTicker):
 
     EXCHANGE = "coinbase"
 
+    def _to_exchange_pair(self, pair: str) -> str:
+        """Coinbase natively uses the unified 'BTC-EUR' format – no conversion."""
+        return pair
+
     def get_market_query(self) -> Dict:
         """Fetch ticker for every configured pair (one request each).
 
         Returns:
-            Normalised dict ``{symbol: {c, a, b}}``.
+            Normalised dict ``{unified_pair: {c, a, b}}``.
         """
         result: Dict = {}
 
@@ -36,7 +40,9 @@ class CoinbaseTicker(RestBaseTicker):
                     "a": float(data["ask"]),
                     "b": float(data["bid"]),
                 }
-                self.logger.debug(f"{pair}: last={data['price']} ask={data['ask']} bid={data['bid']}")
+                self.logger.debug(
+                    f"{pair}: last={data['price']} ask={data['ask']} bid={data['bid']}"
+                )
             except Exception as exc:
                 self.logger.warning(f"Coinbase fetch failed for '{pair}': {exc}")
 

--- a/src/altotrader/ticker/geminiticker.py
+++ b/src/altotrader/ticker/geminiticker.py
@@ -3,8 +3,8 @@
 Uses the public ``/v1/pubticker/{symbol}`` endpoint – no authentication
 required.  One HTTP request is made per trading pair.
 
-Pair format: ``btceur``, ``ethusd``, ``ethbtc`` …
-(Gemini uses lowercase, no separator)
+Pair format: ``BTC-EUR``, ``ETH-USD``, ``ETH-BTC`` …
+(unified hyphen-separated format; converted to lowercase ``btceur`` internally)
 """
 from __future__ import annotations
 
@@ -20,19 +20,23 @@ class GeminiTicker(RestBaseTicker):
 
     EXCHANGE = "gemini"
 
+    def _to_exchange_pair(self, pair: str) -> str:
+        """Gemini uses lowercase, no-separator symbols: ``BTC-EUR`` → ``btceur``."""
+        return pair.replace("-", "").lower()
+
     def get_market_query(self) -> Dict:
         """Fetch ticker for every configured pair (one request each).
 
         Returns:
-            Normalised dict ``{symbol: {c, a, b}}``.
-            Keys preserve the original casing from ``pairs_yaml`` so the
-            caller doesn't need to know about Gemini's lowercase convention.
+            Normalised dict ``{unified_pair: {c, a, b}}``
+            (keys are the original YAML pair names, e.g. ``'BTC-EUR'``).
         """
         result: Dict = {}
 
         for pair in self.pairs_list:
             try:
-                data = self._get(f"{_BASE_URL}/pubticker/{pair.lower()}")
+                ex_sym = self._to_exchange_pair(pair)   # btceur
+                data   = self._get(f"{_BASE_URL}/pubticker/{ex_sym}")
                 result[pair] = {
                     "c": float(data["last"]),
                     "a": float(data["ask"]),

--- a/src/altotrader/ticker/kraken_ws_ticker.py
+++ b/src/altotrader/ticker/kraken_ws_ticker.py
@@ -22,11 +22,12 @@ Or use it as a context manager:
         service = TickerUpdateService(ticker)
         service.update_pairs_ticker(...)
 
-Kraken WS pair format
----------------------
-The REST API uses pairs like 'XXBTZEUR', but the WS API uses 'XBT/EUR'.
-This class handles the conversion automatically via *PAIR_MAP*.  Add any
-missing mappings to PAIR_MAP as needed.
+Pair format
+-----------
+Pairs in the YAML file use the unified hyphen-separated convention (e.g.
+``BTC-EUR``, ``ETH-BTC``).  The ticker converts them to Kraken's WS format
+(``XBT/EUR``, ``ETH/XBT``) automatically via *PAIR_MAP*.  Add any missing
+mappings to PAIR_MAP as needed.
 """
 
 import json
@@ -41,24 +42,25 @@ import pandas as pd
 from altotrader.logging_config import setup_logging
 from altotrader.ticker.baseticker import BaseTicker
 
-# ── REST → WS pair name mapping ───────────────────────────────────────────────
+# ── Unified pair → Kraken WS pair name mapping ────────────────────────────────
+# Add new pairs here as needed.
 PAIR_MAP: Dict[str, str] = {
-    "XXBTZEUR":  "XBT/EUR",
-    "XETHZEUR":  "ETH/EUR",
-    "XETHXXBT":  "ETH/XBT",
-    "SOLZEUR":   "SOL/EUR",
-    "SOLXBT":    "SOL/XBT",
-    "ADAZEUR":   "ADA/EUR",
-    "ADAXBT":    "ADA/XBT",
-    "LINKZEUR":  "LINK/EUR",
-    "LINKXBT":   "LINK/XBT",
-    "XXRPZEUR":  "XRP/EUR",
-    "XXRPXXBT":  "XRP/XBT",
-    "DOTZEUR":   "DOT/EUR",
-    "DOTXBT":    "DOT/XBT",
+    "BTC-EUR":  "XBT/EUR",
+    "ETH-EUR":  "ETH/EUR",
+    "ETH-BTC":  "ETH/XBT",
+    "SOL-EUR":  "SOL/EUR",
+    "SOL-BTC":  "SOL/XBT",
+    "ADA-EUR":  "ADA/EUR",
+    "ADA-BTC":  "ADA/XBT",
+    "LINK-EUR": "LINK/EUR",
+    "LINK-BTC": "LINK/XBT",
+    "XRP-EUR":  "XRP/EUR",
+    "XRP-BTC":  "XRP/XBT",
+    "DOT-EUR":  "DOT/EUR",
+    "DOT-BTC":  "DOT/XBT",
 }
-# Reverse mapping: WS name → REST name
-_WS_TO_REST: Dict[str, str] = {v: k for k, v in PAIR_MAP.items()}
+# Reverse mapping: WS name → unified pair name
+_WS_TO_UNIFIED: Dict[str, str] = {v: k for k, v in PAIR_MAP.items()}
 
 _WS_URL = "wss://ws.kraken.com"
 _RECONNECT_DELAY = 5   # seconds between reconnect attempts
@@ -127,17 +129,18 @@ class KrakenWsTicker(BaseTicker):
         self.logger.info("WebSocket thread stopped.")
 
     def get_market_query(self) -> dict:
-        """Return latest cached prices in the same format as KrakenTicker.
+        """Return latest cached prices keyed by unified pair name.
 
-        Returns a dict keyed by REST pair name, with sub-dicts for c/a/b.
+        Returns a dict keyed by unified pair name (e.g. 'BTC-EUR'), with
+        sub-dicts for c/a/b (list format for KrakenTicker compatibility).
         Returns an empty dict if no data has been received yet.
         """
         with self._lock:
             result = {}
             for ws_pair, prices in self._prices.items():
-                rest_pair = _WS_TO_REST.get(ws_pair)
-                if rest_pair:
-                    result[rest_pair] = {
+                unified = _WS_TO_UNIFIED.get(ws_pair)
+                if unified:
+                    result[unified] = {
                         "c": [prices.get("c", 0.0)],
                         "a": [prices.get("a", 0.0)],
                         "b": [prices.get("b", 0.0)],

--- a/src/altotrader/ticker/krakenticker.py
+++ b/src/altotrader/ticker/krakenticker.py
@@ -4,52 +4,94 @@ import krakenex
 import time
 import os
 import logging
-from typing import List
+from typing import Dict, List
 import datetime
 
 from altotrader.logging_config import setup_logging
 from altotrader.ticker.baseticker import BaseTicker
 
+# ── Unified pair → Kraken REST pair mapping ───────────────────────────────────
+# Add new pairs here as needed.
+KRAKEN_UNIFIED_TO_REST: Dict[str, str] = {
+    "BTC-EUR":  "XXBTZEUR",
+    "ETH-EUR":  "XETHZEUR",
+    "ETH-BTC":  "XETHXXBT",
+    "SOL-EUR":  "SOLZEUR",
+    "SOL-BTC":  "SOLXBT",
+    "ADA-EUR":  "ADAZEUR",
+    "ADA-BTC":  "ADAXBT",
+    "LINK-EUR": "LINKZEUR",
+    "LINK-BTC": "LINKXBT",
+    "XRP-EUR":  "XXRPZEUR",
+    "XRP-BTC":  "XXRPXXBT",
+    "DOT-EUR":  "DOTZEUR",
+    "DOT-BTC":  "DOTXBT",
+}
+
+# Reverse: Kraken REST pair → unified
+_REST_TO_UNIFIED: Dict[str, str] = {v: k for k, v in KRAKEN_UNIFIED_TO_REST.items()}
+
 
 class KrakenTicker(BaseTicker):
     def __init__(self, pairs_yaml: str, log_dir: str = 'logs'):
         """
-        Object streamt über krakenex.API die aktuellen Marktpreise
+        Object streamt über krakenex.API die aktuellen Marktpreise.
+
+        Pairs in the YAML must use the unified 'BTC-EUR' format.
         """
 
         self.timestamp = None
         self.k = krakenex.API()
         self.pairs_list = self.load_yaml(pairs_yaml)
-        self._timestamp_last_fetch: datetime = None
+        self._timestamp_last_fetch: datetime.datetime = None
 
         setup_logging(log_filename='krakenticker.logs', log_dir=log_dir)
 
         self.logger = logging.getLogger(__name__)
 
+        # Warn about pairs not in the mapping
+        for pair in self.pairs_list:
+            if pair not in KRAKEN_UNIFIED_TO_REST:
+                self.logger.warning(
+                    f"No Kraken REST mapping for '{pair}'. "
+                    "Add it to KRAKEN_UNIFIED_TO_REST in krakenticker.py."
+                )
+
         self.logger.info(
-            f"Instatiated KrakenTicker with asset pairs: {self.pairs_list}")
+            f"Instantiated KrakenTicker with pairs: {self.pairs_list}")
 
     def get_market_query(self) -> dict:
+        """Fetch all Kraken ticker data and return it keyed by unified pair names.
+
+        Returns:
+            ``{"BTC-EUR": {"c": [...], "a": [...], "b": [...]}, ...}``
+        """
         try:
             response = self.k.query_public("Ticker")
             self.timestamp_last_fetch = self.current_timestamp()
-            return response.get("result", {})
+            raw = response.get("result", {})
+
+            # Translate Kraken REST keys to unified pair names
+            result = {}
+            for rest_key, data in raw.items():
+                unified = _REST_TO_UNIFIED.get(rest_key)
+                if unified is not None:
+                    result[unified] = data
+
+            return result
         except Exception as e:
             self.logger.error(f"Error fetching market result: {e}")
             return {}
 
     def get_last_ticker(self, ticker_entry: str, market_query: dict = None) -> pd.DataFrame:
-        """Fetches the latest ticker prices for the trading pairs as a DataFrame
+        """Fetches the latest ticker prices for the trading pairs as a DataFrame.
 
         Args:
             ticker_entry (str): only accepts c -> close, a -> ask, b -> bid
             market_query (dict): inject from self.get_market_query()
 
-        Raises:
-            ValueError: _description_
-
         Returns:
-            pd.DataFrame: ticker values with timestamp index
+            pd.DataFrame: ticker values with timestamp index, columns = unified pairs
         """
 
         self.logger.info(f"ticker_entry: {ticker_entry}")
@@ -70,13 +112,13 @@ class KrakenTicker(BaseTicker):
             if not isinstance(market_query, dict):
                 self.logger.error(
                     f"Invalid market query response: {market_query}")
-                return pd.DataFrame()  # Return empty DataFrame if invalid response
+                return pd.DataFrame()
 
             timestamp_now = self.timestamp_last_fetch
 
             for pair in self.pairs_list:
-                pair_data = market_query.get(pair, {})
-                pair_ticker = pair_data.get(f"{ticker_entry}", [])
+                pair_data   = market_query.get(pair, {})
+                pair_ticker = pair_data.get(ticker_entry, [])
 
                 if (
                     not pair_ticker
@@ -84,7 +126,8 @@ class KrakenTicker(BaseTicker):
                     or len(pair_ticker) < 1
                 ):
                     self.logger.error(
-                        f"Missing or invalid ticker data for {pair}: {pair_data} on {ticker_entry}"
+                        f"Missing or invalid ticker data for {pair}: "
+                        f"{pair_data} on {ticker_entry}"
                     )
                     continue
 

--- a/src/altotrader/ticker/mexcticker.py
+++ b/src/altotrader/ticker/mexcticker.py
@@ -9,8 +9,8 @@ Both endpoints return data for all symbols when called without parameters,
 so we make only two requests per polling cycle regardless of how many pairs
 are configured.
 
-Pair format: ``BTCUSDT``, ``ETHBTC``, ``SOLUSDT`` …
-(MEXC uppercase, no separator – same convention as Binance)
+Pair format: ``BTC-USDT``, ``ETH-BTC``, ``SOL-USDT`` …
+(unified hyphen-separated format; converted to ``BTCUSDT`` internally)
 """
 from __future__ import annotations
 
@@ -26,6 +26,8 @@ class MEXCTicker(RestBaseTicker):
 
     EXCHANGE = "mexc"
 
+    # _to_exchange_pair() inherited default: "BTC-USDT" → "BTCUSDT" ✓
+
     def get_market_query(self) -> Dict:
         """Fetch last price + best bid/ask for all configured pairs.
 
@@ -33,13 +35,15 @@ class MEXCTicker(RestBaseTicker):
         configured pair list.
 
         Returns:
-            Normalised dict ``{symbol: {c, a, b}}``.
+            Normalised dict ``{unified_pair: {c, a, b}}``.
         """
         try:
+            reverse = self._exchange_to_unified_map()  # BTCUSDT → BTC-USDT
+
             price_data = self._get(f"{_BASE_URL}/ticker/price")
             book_data  = self._get(f"{_BASE_URL}/ticker/bookTicker")
 
-            # Build lookup maps  {symbol → value}
+            # Build lookup maps  {exchange_symbol → value}
             price_map: Dict[str, float] = {}
             for item in (price_data if isinstance(price_data, list) else [price_data]):
                 price_map[item["symbol"]] = float(item["price"])
@@ -52,18 +56,18 @@ class MEXCTicker(RestBaseTicker):
                 }
 
             result: Dict = {}
-            for pair in self.pairs_list:
-                if pair not in price_map or pair not in book_map:
-                    self.logger.warning(f"MEXC: no data for pair '{pair}'")
+            for ex_sym, unified in reverse.items():
+                if ex_sym not in price_map or ex_sym not in book_map:
+                    self.logger.warning(f"MEXC: no data for pair '{unified}' ({ex_sym})")
                     continue
-                result[pair] = {
-                    "c": price_map[pair],
-                    "a": book_map[pair]["a"],
-                    "b": book_map[pair]["b"],
+                result[unified] = {
+                    "c": price_map[ex_sym],
+                    "a": book_map[ex_sym]["a"],
+                    "b": book_map[ex_sym]["b"],
                 }
                 self.logger.debug(
-                    f"{pair}: last={price_map[pair]} "
-                    f"ask={book_map[pair]['a']} bid={book_map[pair]['b']}"
+                    f"{unified}: last={price_map[ex_sym]} "
+                    f"ask={book_map[ex_sym]['a']} bid={book_map[ex_sym]['b']}"
                 )
 
             if result:

--- a/src/altotrader/ticker/rest_base_ticker.py
+++ b/src/altotrader/ticker/rest_base_ticker.py
@@ -50,6 +50,25 @@ class RestBaseTicker(BaseTicker):
             f"Initialised {self.EXCHANGE}Ticker with pairs: {self.pairs_list}"
         )
 
+    # ── Pair-format conversion ────────────────────────────────────────────────
+
+    def _to_exchange_pair(self, pair: str) -> str:
+        """Convert the unified ``'BTC-EUR'`` format to the exchange-specific symbol.
+
+        The default implementation strips the hyphen separator (``'BTC-EUR'``
+        → ``'BTCEUR'``), which works for Binance and MEXC.  Override in
+        subclasses that use a different convention.
+        """
+        return pair.replace("-", "")
+
+    def _exchange_to_unified_map(self) -> Dict[str, str]:
+        """Return ``{exchange_symbol: unified_pair}`` for all configured pairs.
+
+        Useful for translating API responses back to the canonical pair name
+        used in the YAML file.
+        """
+        return {self._to_exchange_pair(p): p for p in self.pairs_list}
+
     # ── HTTP helper ────────────────────────────────────────────────────────────
 
     def _get(self, url: str, **kwargs) -> dict | list:


### PR DESCRIPTION
## Summary

Alle Ticker verwenden jetzt ein einheitliches `BASE-QUOTE` Pair-Format (z.B. `BTC-EUR`, `ETH-BTC`) in YAML-Konfigurationsdateien und in den Rückgaben von `get_market_query()` und `get_last_ticker()`.

### Architektur

`RestBaseTicker` stellt zwei neue Hilfsmethoden bereit:
- `_to_exchange_pair(pair)`: konvertiert `BTC-EUR` ins exchange-spezifische Format (Default: entfernt Bindestrich → `BTCEUR`)
- `_exchange_to_unified_map()`: baut `{exchange_symbol: unified_pair}` Lookup-Map

### Konvertierung pro Exchange (intern, unsichtbar für den Nutzer)

| Ticker | Unified → Exchange |
|---|---|
| `BinanceTicker` / `BinanceWsTicker` | `BTC-EUR` → `BTCEUR` |
| `CoinbaseTicker` | `BTC-EUR` → `BTC-EUR` (kein Change) |
| `GeminiTicker` | `BTC-EUR` → `btceur` |
| `MEXCTicker` | `BTC-USDT` → `BTCUSDT` |
| `KrakenTicker` | `BTC-EUR` → `XXBTZEUR` (via `KRAKEN_UNIFIED_TO_REST`) |
| `KrakenWsTicker` | `BTC-EUR` → `XBT/EUR` (via `PAIR_MAP`) |

### Geänderte Dateien
- `rest_base_ticker.py`: `_to_exchange_pair()` + `_exchange_to_unified_map()`
- `binanceticker.py`, `coinbaseticker.py`, `geminiticker.py`, `mexcticker.py`: Konvertierung + unified Keys in Rückgabe
- `binance_ws_ticker.py`: Stream-Namen + `_ex_to_unified` Reverse-Map
- `krakenticker.py`: `KRAKEN_UNIFIED_TO_REST` Mapping, `get_market_query()` gibt unified Keys zurück
- `kraken_ws_ticker.py`: `PAIR_MAP` auf unified Format umgestellt, `_WS_TO_UNIFIED` statt `_WS_TO_REST`
- Alle YAML-Dateien auf `BTC-EUR` Format aktualisiert

## Test plan
- [ ] `python -m pytest` – **100 passed, 2 skipped**
- [ ] Alle Ticker-Tests prüfen unified Pair-Namen in Rückgaben
- [ ] `test_krakenticker.py`: Mock-API gibt Kraken-REST-Format zurück, Assertions prüfen unified Keys

https://claude.ai/code/session_01HQU7KNPmCQP8eZm9DcY7cf