### PR TITLE
README, config fixes & multi-bucket DataLoader

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,8 +186,8 @@ backtest_config = {
     "taker_fee":        0.004,
     "slippage_pct":     0.0005,   # 0.05 % slippage on each side
     "initial_invest":   1000,
-    "base_currency":    "ZEUR",
-    "trading_currency": "XXBT",
+    "base_currency":    "EUR",    # pair will be constructed as "BTC-EUR"
+    "trading_currency": "BTC",
 }
 
 loader  = DataLoader(loader_config)

--- a/README.md
+++ b/README.md
@@ -1,53 +1,262 @@
 # AltoTrader
 
-**Automated trading on the kraken exchange**
+Automated crypto trading framework with support for multiple exchanges, InfluxDB data storage, and a look-ahead-bias-free backtesting engine.
 
-**Trained to inform you via Twitter on the latest trades**
+## Features
 
-## Introduction
-This is a trading bot to perform automated trading on the kraken exchange via [Kraken's API](https://www.kraken.com/help/api). The bot requires Python 3 and a module called ``krakenex``. You can simply install it by running:
+- **Multi-exchange support** – Kraken, Binance, Coinbase, Gemini, MEXC
+- **REST and WebSocket tickers** – polling or real-time streaming per exchange
+- **Unified pair format** – `BTC-EUR`, `ETH-BTC` across all exchanges
+- **InfluxDB v2 storage** – time-series database for market price data
+- **Backtesting engine** – MA crossover strategy with slippage, realistic fees, Sharpe ratio, drawdown analysis, grid search
+- **Docker Compose** – one-command deployment with InfluxDB dashboard
+- **Export / remote fetch** – pull historical data to CSV or Parquet
 
-``pip3 install krakenex``
+---
 
-The trading strategy is based on the intersection of rolling means with different window width. Which window width is the best  highly depends on the traded asset pairs and the current market situation. Therefore, no recommendation on the windows can be given.
+## Project Structure
 
+```
+AltoTrader/
+├── src/altotrader/
+│   ├── ticker/
+│   │   ├── baseticker.py          # Abstract base class
+│   │   ├── rest_base_ticker.py    # Shared REST base (get_last_ticker, _to_exchange_pair)
+│   │   ├── krakenticker.py        # Kraken REST
+│   │   ├── kraken_ws_ticker.py    # Kraken WebSocket
+│   │   ├── binanceticker.py       # Binance REST
+│   │   ├── binance_ws_ticker.py   # Binance WebSocket
+│   │   ├── coinbaseticker.py      # Coinbase Exchange REST
+│   │   ├── geminiticker.py        # Gemini REST
+│   │   └── mexcticker.py          # MEXC REST
+│   ├── database/
+│   │   ├── update_service.py      # Writes ticker data to InfluxDB
+│   │   └── export_prices.py       # Exports data to CSV/Parquet
+│   └── backtest/
+│       ├── dataloader.py          # Loads and resamples CSV exports
+│       └── backtest_engine.py     # MA crossover backtest + grid search
+├── Examples/
+│   ├── run_update_service.py      # Data collection entry point
+│   ├── fetch_from_remote.py       # Fetch data from remote InfluxDB
+│   ├── kraken_pairs.yaml
+│   ├── binance_pairs.yaml
+│   ├── coinbase_pairs.yaml
+│   ├── gemini_pairs.yaml
+│   └── mexc_pairs.yaml
+├── Dockerfile
+├── docker-compose.yml
+└── env/.env.example
+```
 
-## Step by Step
+---
 
-### 0. Kraken key
-The magic of automated trading will only work out for you if you have a kraken account with funding. If not, create a [Kraken](https://www.kraken.com/) account, transfer some coins and generate an API key with the necessary rights:
+## Installation
 
-``keykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykey
-secretsecretsecretsecretsecretsecretsecretsecretsecretsecretsecretsecretsecretsecretsecret``
+Requires Python ≥ 3.10.
 
-store the two keys in a file called ``kraken.key`` which you will need later.
+```bash
+git clone https://github.com/mhansinger/AltoTrader.git
+cd AltoTrader
+pip install .
+# Development extras (pytest, black …)
+pip install ".[dev]"
+```
 
+---
 
-### 1. Asset pair
-Decide which asset pair you would like to trade. In this example 'step by step' we assume you'd like to trade between Bitcoin and EUR, so the assets are:
-``
-asset1='XXBT'
-asset2='ZEUR'
-``
+## Pair Format
 
-### 2. Stream the market data
-For the computation of rolling mean averages the trader will need historical market data. Therefore you have to establish a data base with historical market prices. Inside your trading directory, let's assume you called it ``XXBTZEUR``, create another directory called:
-``XXBTZEUR_data``
+All exchanges use the unified **`BASE-QUOTE`** format:
 
-This name is important and must contain the traded asset pair in the begining, as the trading enginge will search for this particular directory. Copy the content of [Stream](https://github.com/mhansinger/AltoTrader/tree/master/Stream) into it. Modify ``Beispiel_stream.py`` according to your asset pairs and run it. It will request the current market price from kraken exchange every minute and update your data base ``XXBTZEUR_Series.csv``every 10 minutes. Of course you can adjust that in the code, too.
+```
+BTC-EUR   ETH-BTC   SOL-USDT   XRP-EUR
+```
 
-### 3. Do some backtesting
-Stream the market prices for some days (better: weeks) into your data base. You'll need to do a bit of backtesting now. Backtesting is crucial for the success of your trading strategy, as it provides you the best window widths to maximize your portfolio. However, this is only a good guess as all your knowledge is based on historical(!) data. There is absolutely no guarantee that the market will behave similarly in the future. So, repeat backtesting from time to time to verify your window widths, as in the end you want a care free life and be on the bright side of trader life, or not?
+Each ticker converts internally to the exchange-specific symbol:
 
-#### How to:
+| Exchange | Unified | Internal |
+|---|---|---|
+| Binance / MEXC | `BTC-EUR` | `BTCEUR` |
+| Coinbase | `BTC-EUR` | `BTC-EUR` |
+| Gemini | `BTC-EUR` | `btceur` |
+| Kraken REST | `BTC-EUR` | `XXBTZEUR` |
+| Kraken WS | `BTC-EUR` | `XBT/EUR` |
 
-### 4. Set up the trading engine
-Open another terminal and copy the Python files from [Trade_Algo](https://github.com/mhansinger/AltoTrader/tree/master/Trade_Algo) into your trading directory (e.g. ``XXBTZEUR``). Copy also the ``kraken.key`` into this directory.
-Have a look into the ``main.py`` file, change for the correct asset pairs and adjust the ``short`` and ``long`` window width in:
+---
 
-``XXBT_input = set_input(asset1='XXBT', asset2='ZEUR', long=100, short=47)``
-Be sure to have somehow 'good' values for the windows, otherwise the trader will burn your coins easily.
+## Configuration
 
-That's on your OWN RISK.
+Copy `env/.env.example` to `.env` and fill in your values:
 
-### 4. (Optional) Set up Twitter engine
+```bash
+cp env/.env.example .env
+```
+
+```dotenv
+INFLUXDB_INIT_BUCKET=altotrader
+INFLUXDB_INIT_ORG=myorg
+INFLUXDB_INIT_ADMIN_TOKEN=your-token-here
+INFLUXDB_INIT_PASSWORD=your-password
+INFLUX_URL=http://localhost:8086
+```
+
+---
+
+## Data Streaming
+
+### REST polling (default)
+
+```bash
+python Examples/run_update_service.py --mode rest
+```
+
+### WebSocket (Kraken or Binance)
+
+```bash
+# Kraken WebSocket
+python Examples/run_update_service.py --mode websocket
+
+# Binance WebSocket (edit run_update_service.py to swap ticker)
+```
+
+### Selecting an exchange
+
+Edit `Examples/run_update_service.py` (or pass `--mode`) and swap the ticker:
+
+```python
+from altotrader.ticker.binanceticker      import BinanceTicker
+from altotrader.ticker.binance_ws_ticker  import BinanceWsTicker
+from altotrader.ticker.coinbaseticker     import CoinbaseTicker
+from altotrader.ticker.geminiticker       import GeminiTicker
+from altotrader.ticker.mexcticker         import MEXCTicker
+from altotrader.ticker.krakenticker       import KrakenTicker
+from altotrader.ticker.kraken_ws_ticker   import KrakenWsTicker
+
+ticker = BinanceTicker(pairs_yaml="Examples/binance_pairs.yaml")
+service = TickerUpdateService(ticker)
+```
+
+All tickers are drop-in replacements – `TickerUpdateService` works with any of them.
+
+### Pairs YAML
+
+```yaml
+# Examples/binance_pairs.yaml
+items:
+  - BTC-EUR
+  - ETH-EUR
+  - ETH-BTC
+```
+
+---
+
+## Docker Deployment
+
+Build and start InfluxDB + the streaming service:
+
+```bash
+docker compose up --build -d
+```
+
+The InfluxDB dashboard is available at **http://localhost:8086** (or your server's IP).
+
+To use a different exchange, set the `MODE` environment variable:
+
+```bash
+MODE=websocket docker compose up -d
+```
+
+---
+
+## Backtesting
+
+### Quick start
+
+```python
+from altotrader.backtest.dataloader     import DataLoader
+from altotrader.backtest.backtest_engine import BacktestEngine
+
+loader_config = {
+    "export_path": "Examples/ticker_export",
+    "latest_days": 20,
+    "logs_dir":    "logs",
+}
+backtest_config = {
+    "maker_fee":        0.0025,
+    "taker_fee":        0.004,
+    "slippage_pct":     0.0005,   # 0.05 % slippage on each side
+    "initial_invest":   1000,
+    "base_currency":    "ZEUR",
+    "trading_currency": "XXBT",
+}
+
+loader  = DataLoader(loader_config)
+backtest = BacktestEngine(loader, backtest_config)
+metrics  = backtest.run(window_short=50, window_long=200)
+print(metrics)
+```
+
+### Key metrics returned
+
+| Key | Description |
+|---|---|
+| `total_return_pct` | Strategy return vs initial invest |
+| `buy_and_hold_return_pct` | Passive benchmark |
+| `n_trades` | Number of completed round-trips |
+| `win_rate` | % of profitable trades |
+| `max_drawdown_pct` | Maximum peak-to-trough loss |
+| `max_drawdown_duration_hrs` | Longest drawdown period (hours) |
+| `sharpe_ratio` | Annualised Sharpe (daily returns × √365) |
+| `total_fees` / `taker_fees` / `maker_fees` | Fee breakdown |
+| `final_portfolio_value` | End portfolio value |
+
+### Grid search
+
+```python
+from altotrader.backtest.backtest_engine import run_grid_search
+
+results = run_grid_search(
+    backtest,
+    short_windows=[20, 50, 100],
+    long_windows=[100, 200, 500],
+)
+print(results[["window_short", "window_long", "total_return_pct", "sharpe_ratio"]].head())
+```
+
+### Visualisation
+
+```python
+backtest.plot_results(show=True, save_path="backtest.png")
+```
+
+---
+
+## Exporting Data
+
+Export data from a local or remote InfluxDB to CSV or Parquet:
+
+```bash
+python Examples/fetch_from_remote.py \
+    --url   http://my-server:8086 \
+    --token $INFLUXDB_INIT_ADMIN_TOKEN \
+    --org   myorg \
+    --bucket altotrader \
+    --days  30 \
+    --out   data/export.csv
+```
+
+---
+
+## Tests
+
+```bash
+python -m pytest
+```
+
+100 tests, 2 skipped (Kraken build-environment guard in CI).
+
+---
+
+## Disclaimer
+
+This software is for educational purposes only. Automated trading carries significant financial risk. Past backtesting performance does not guarantee future results. Use at your own risk.

--- a/Tests/test_backtest_engine.py
+++ b/Tests/test_backtest_engine.py
@@ -30,9 +30,9 @@ class _MockDataLoader:
             f"{window_long}min").mean()
 
 
-PAIR = "XXBTZEUR"
-BASE = "ZEUR"
-TRADING = "XXBT"
+BASE    = "EUR"
+TRADING = "BTC"
+PAIR    = f"{TRADING}-{BASE}"   # "BTC-EUR"
 
 BACKTEST_CONFIG = {
     "maker_fee":        0.0025,

--- a/Tests/test_dataloader.py
+++ b/Tests/test_dataloader.py
@@ -129,6 +129,88 @@ class TestComputeRollingMeans:
 
 # ── _iterpolate_nan ───────────────────────────────────────────────────────────
 
+class TestMultiSource:
+    """DataLoader with export_sources list (multiple exchange buckets)."""
+
+    def _make_source(self, tmp_dir, prefix, pair, n_rows=50):
+        """Write CSV files for one exchange bucket into tmp_dir."""
+        dates  = pd.date_range("2025-01-01", periods=n_rows, freq="1min")
+        prices = np.linspace(40_000, 42_000, n_rows)
+        os.makedirs(tmp_dir, exist_ok=True)
+        for suffix, mult in [("a", 1.001), ("b", 0.999), ("c", 1.0)]:
+            df = pd.DataFrame({pair: prices * mult}, index=dates)
+            df.index.name = "timestamp"
+            df.to_csv(os.path.join(tmp_dir, f"{prefix}_latest_20d_{suffix}.csv"))
+
+    def test_loads_two_sources_and_merges_columns(self, tmp_path):
+        kraken_dir  = str(tmp_path / "kraken")
+        binance_dir = str(tmp_path / "binance")
+        self._make_source(kraken_dir,  "kraken",  "BTC-EUR")
+        self._make_source(binance_dir, "binance", "ETH-BTC")
+
+        config = {
+            "export_sources": [
+                {"export_path": kraken_dir,  "file_prefix": "kraken",  "latest_days": 20},
+                {"export_path": binance_dir, "file_prefix": "binance", "latest_days": 20},
+            ],
+            "logs_dir": str(tmp_path),
+        }
+        loader = DataLoader(config)
+        loader.load_csv_export()
+
+        # Both pairs must appear as columns
+        assert "BTC-EUR" in loader.ticker_current.columns
+        assert "ETH-BTC" in loader.ticker_current.columns
+
+    def test_same_pair_two_sources_combined(self, tmp_path):
+        """Two sources with the same pair – columns deduplicated by pandas join."""
+        dir_a = str(tmp_path / "a")
+        dir_b = str(tmp_path / "b")
+        self._make_source(dir_a, "src_a", "BTC-EUR")
+        self._make_source(dir_b, "src_b", "BTC-EUR")
+
+        config = {
+            "export_sources": [
+                {"export_path": dir_a, "file_prefix": "src_a", "latest_days": 20},
+                {"export_path": dir_b, "file_prefix": "src_b", "latest_days": 20},
+            ],
+            "logs_dir": str(tmp_path),
+        }
+        loader = DataLoader(config)
+        loader.load_csv_export()
+        assert loader.ticker_current is not None
+
+    def test_missing_source_warns_but_loads_rest(self, tmp_path):
+        """A missing file in one source should not crash – others still load."""
+        good_dir = str(tmp_path / "good")
+        self._make_source(good_dir, "good", "BTC-EUR")
+
+        config = {
+            "export_sources": [
+                {"export_path": good_dir,              "file_prefix": "good",    "latest_days": 20},
+                {"export_path": str(tmp_path / "bad"), "file_prefix": "missing", "latest_days": 20},
+            ],
+            "logs_dir": str(tmp_path),
+        }
+        loader = DataLoader(config)
+        loader.load_csv_export()
+        assert "BTC-EUR" in loader.ticker_current.columns
+
+    def test_single_source_via_export_sources(self, tmp_path):
+        """export_sources with one entry behaves identically to single-source mode."""
+        d = str(tmp_path / "kraken")
+        self._make_source(d, "kraken", "BTC-EUR")
+        config = {
+            "export_sources": [
+                {"export_path": d, "file_prefix": "kraken", "latest_days": 20},
+            ],
+            "logs_dir": str(tmp_path),
+        }
+        loader = DataLoader(config)
+        loader.load_csv_export()
+        assert "BTC-EUR" in loader.ticker_current.columns
+
+
 class TestInterpolateNan:
     def test_interpolates_missing_values(self, tmp_path):
         config = _make_csv_files(str(tmp_path))

--- a/src/altotrader/backtest/backtest_engine.py
+++ b/src/altotrader/backtest/backtest_engine.py
@@ -16,7 +16,8 @@ class BacktestEngine:
         self.initial_invest = backtest_config.get('initial_invest', 1000)
         self.trading_currency = backtest_config.get("trading_currency")
         self.base_currency    = backtest_config.get("base_currency")
-        self.pair = self.trading_currency + self.base_currency
+        # Unified pair format: "BTC-EUR", matching exported CSV column names
+        self.pair = f"{self.trading_currency}-{self.base_currency}"
         # Slippage applied on top of ask/bid spread (0.0005 = 0.05%)
         self.slippage_pct = backtest_config.get('slippage_pct', 0.0005)
 
@@ -458,17 +459,21 @@ def run_grid_search(
 
 
 if __name__ == '__main__':
-    loader_dict = {'export_path': "Examples/ticker_export",
-                   "latest_days": 20, "logs_dir": 'logs'}
+    loader_dict = {
+        'export_path': "Examples/ticker_export",
+        "latest_days": 20,
+        "file_prefix": "altotrader",  # must match InfluxDB bucket name
+        "logs_dir":    'logs',
+    }
     testloader = DataLoader(loader_dict)
 
     backtest_config = {
-        "maker_fee":    0.0025,
-        "taker_fee":    0.004,
-        "slippage_pct": 0.0005,
-        "initial_invest": 1000,
-        "base_currency":    "ZEUR",
-        "trading_currency": "XXBT",
+        "maker_fee":        0.0025,
+        "taker_fee":        0.004,
+        "slippage_pct":     0.0005,
+        "initial_invest":   1000,
+        "base_currency":    "EUR",   # pair will be "BTC-EUR"
+        "trading_currency": "BTC",
     }
 
     backtest = BacktestEngine(testloader, backtest_config)

--- a/src/altotrader/backtest/dataloader.py
+++ b/src/altotrader/backtest/dataloader.py
@@ -35,15 +35,18 @@ class DataLoader:
 
         export_path = self.config_dict.get('export_path')
         days = self.config_dict.get('latest_days')
+        # Optional prefix override; defaults to 'krakenticker' for backward compat
+        prefix = self.config_dict.get('file_prefix', 'krakenticker')
 
         def load_and_resample(suffix: str) -> pd.DataFrame:
             path = join(
-                export_path, f"krakenticker_latest_{days}d_{suffix}.csv")
+                export_path, f"{prefix}_latest_{days}d_{suffix}.csv")
             self.logger.debug(f"Loading: {path}")
             df = pd.read_csv(path, index_col="timestamp",
                              parse_dates=["timestamp"])
             df = df.sort_index()
-            df = df.drop('ticker_entry', axis=1)
+            if 'ticker_entry' in df.columns:
+                df = df.drop('ticker_entry', axis=1)
 
             return df.resample("1min").mean()
 

--- a/src/altotrader/backtest/dataloader.py
+++ b/src/altotrader/backtest/dataloader.py
@@ -188,8 +188,12 @@ class DataLoader:
 
 if __name__ == '__main__':
 
-    my_dict = {'export_path': "Examples/ticker_export",
-               "latest_days": 20, "logs_dir": 'logs'}
+    my_dict = {
+        'export_path': "Examples/ticker_export",
+        "latest_days": 20,
+        "file_prefix": "altotrader",  # must match InfluxDB bucket name
+        "logs_dir":    'logs',
+    }
     testloader = DataLoader(my_dict)
     testloader.load_csv_export()
     testloader.compute_rolling_means(window_short=50, window_long=200)

--- a/src/altotrader/backtest/dataloader.py
+++ b/src/altotrader/backtest/dataloader.py
@@ -29,30 +29,88 @@ class DataLoader:
 
         # TODO: update config
 
-    def load_csv_export(self) -> pd.DataFrame:
-        """reads in CSV exports for ask, bid, current price"""
+    def load_csv_export(self) -> None:
+        """Load CSV exports for ask, bid, and current price.
+
+        Supports two config modes:
+
+        **Single source** (backward compatible)::
+
+            {
+                "export_path": "exports/kraken",
+                "file_prefix": "kraken",   # default: "krakenticker"
+                "latest_days": 30,
+            }
+
+        **Multiple sources** – useful when streaming from different exchange
+        buckets.  All sources are loaded and merged column-wise (outer join
+        on the time index, then NaN-interpolated)::
+
+            {
+                "export_sources": [
+                    {"export_path": "exports/kraken",  "file_prefix": "kraken",  "latest_days": 30},
+                    {"export_path": "exports/binance", "file_prefix": "binance", "latest_days": 30},
+                ],
+            }
+        """
         self.logger.info('loading exported csv files')
 
-        export_path = self.config_dict.get('export_path')
-        days = self.config_dict.get('latest_days')
-        # Optional prefix override; defaults to 'krakenticker' for backward compat
-        prefix = self.config_dict.get('file_prefix', 'krakenticker')
+        # Build a list of (export_path, prefix, days) tuples
+        sources = self.config_dict.get('export_sources')
+        if sources:
+            # Multi-source mode
+            source_list = [
+                (s['export_path'],
+                 s.get('file_prefix', 'krakenticker'),
+                 s.get('latest_days', self.config_dict.get('latest_days', 30)))
+                for s in sources
+            ]
+        else:
+            # Single-source mode (backward compatible)
+            source_list = [(
+                self.config_dict.get('export_path'),
+                self.config_dict.get('file_prefix', 'krakenticker'),
+                self.config_dict.get('latest_days', 30),
+            )]
 
-        def load_and_resample(suffix: str) -> pd.DataFrame:
-            path = join(
-                export_path, f"{prefix}_latest_{days}d_{suffix}.csv")
+        def load_source(export_path: str, prefix: str, days: int, suffix: str) -> pd.DataFrame:
+            path = join(export_path, f"{prefix}_latest_{days}d_{suffix}.csv")
             self.logger.debug(f"Loading: {path}")
-            df = pd.read_csv(path, index_col="timestamp",
-                             parse_dates=["timestamp"])
+            df = pd.read_csv(path, index_col="timestamp", parse_dates=["timestamp"])
             df = df.sort_index()
             if 'ticker_entry' in df.columns:
                 df = df.drop('ticker_entry', axis=1)
-
             return df.resample("1min").mean()
 
-        self.ticker_ask = load_and_resample("a")
-        self.ticker_bid = load_and_resample("b")
-        self.ticker_current = load_and_resample("c")
+        def load_and_merge(suffix: str) -> pd.DataFrame:
+            frames = []
+            for export_path, prefix, days in source_list:
+                try:
+                    frames.append(load_source(export_path, prefix, days, suffix))
+                except FileNotFoundError as e:
+                    self.logger.warning(f"File not found, skipping source: {e}")
+            if not frames:
+                raise RuntimeError(
+                    f"No CSV files could be loaded for suffix '{suffix}'. "
+                    "Check export_path and file_prefix in your config."
+                )
+            if len(frames) == 1:
+                return frames[0]
+            # Outer-join on time index; duplicate pair columns are averaged
+            combined = pd.concat(frames, axis=1)
+            # Group duplicate column names and take the mean
+            merged = combined.T.groupby(level=0).mean().T
+            n_sources = len(frames)
+            n_pairs   = len(merged.columns)
+            self.logger.info(
+                f"Merged {n_sources} source(s) for suffix='{suffix}': "
+                f"{n_pairs} unique pair(s) total"
+            )
+            return merged
+
+        self.ticker_ask     = load_and_merge("a")
+        self.ticker_bid     = load_and_merge("b")
+        self.ticker_current = load_and_merge("c")
 
         # fill NaN if any
         self.ticker_ask = self._iterpolate_nan(self.ticker_ask)


### PR DESCRIPTION
## Summary

### README komplett neu geschrieben
- Projektstruktur mit allen neuen Dateien
- Multi-Exchange Übersicht (Pair-Format Tabelle)
- Installation, Konfiguration, Docker Compose
- Backtesting Quick Start, Metrics-Tabelle, Grid Search, Visualisierung
- Daten-Export CLI

### Bug Fix: Pair-Format Mismatch in BacktestEngine
- `BacktestEngine` konstruierte `"XXBT" + "ZEUR"` = `"XXBTZEUR"`, aber CSV-Spalten heißen `BTC-EUR`
- Fix: `self.pair = f"{trading_currency}-{base_currency}"`
- Config jetzt: `"base_currency": "EUR"`, `"trading_currency": "BTC"`

### Bug Fix: DataLoader Dateiname-Mismatch
- `DataLoader` suchte nach `krakenticker_latest_Nd_x.csv`, aber `export_prices.py` schreibt `{bucket}_latest_Nd_x.csv`
- Fix: neues Config-Feld `file_prefix` (Default: `"krakenticker"` für Rückwärtskompatibilität)
- `ticker_entry`-Spalte-Drop ist jetzt optional (nicht alle Exports haben sie)

### Multi-Bucket DataLoader
- Neuer Config-Modus `export_sources` für mehrere InfluxDB-Buckets (z.B. Kraken + Binance)
- Outer-Join auf Zeitindex; doppelte Pair-Spalten werden gemittelt
- Fehlende Dateien einer Quelle loggen Warnung, restliche Quellen laden weiter

## Test plan
- [ ] `python -m pytest` – **104 passed, 2 skipped**
- [ ] 4 neue Tests in `TestMultiSource`

https://claude.ai/code/session_01HQU7KNPmCQP8eZm9DcY7cf