### PR TITLE
Add 24h trading volume (v) as 4th ticker_entry

### DIFF
--- a/Tests/test_backtest_engine.py
+++ b/Tests/test_backtest_engine.py
@@ -17,6 +17,7 @@ class _MockDataLoader:
         self.ticker_current = pd.DataFrame({pair: prices}, index=dates)
         self.ticker_ask     = pd.DataFrame({pair: prices * 1.001}, index=dates)
         self.ticker_bid     = pd.DataFrame({pair: prices * 0.999}, index=dates)
+        self.ticker_volume  = None   # volume not required for basic tests
         self.rolling_current_short = None
         self.rolling_current_long  = None
 

--- a/Tests/test_binance_ws_ticker.py
+++ b/Tests/test_binance_ws_ticker.py
@@ -35,7 +35,7 @@ def _make_ticker(tmp_path, pairs=None):
     return BinanceWsTicker(pairs_yaml=yaml_path)
 
 
-def _ticker_msg(unified_pair: str, c: str, a: str, b: str) -> str:
+def _ticker_msg(unified_pair: str, c: str, a: str, b: str, v: str = "1000.0") -> str:
     """Build a valid combined-stream 24hrTicker message.
 
     Accepts the unified pair name (e.g. 'BTC-EUR') and converts it to the
@@ -51,6 +51,7 @@ def _ticker_msg(unified_pair: str, c: str, a: str, b: str) -> str:
             "c": c,
             "a": a,
             "b": b,
+            "v": v,        # 24 h base-asset volume
         },
     })
 
@@ -67,11 +68,12 @@ def test_get_market_query_empty_before_start(tmp_path):
 class TestOnMessageValid:
     def test_single_pair_stored(self, tmp_path):
         ticker = _make_ticker(tmp_path)
-        ticker._on_message(None, _ticker_msg("BTC-EUR", "60000", "60010", "59990"))
+        ticker._on_message(None, _ticker_msg("BTC-EUR", "60000", "60010", "59990", "2500.5"))
         assert "BTC-EUR" in ticker._prices
         assert ticker._prices["BTC-EUR"]["c"] == pytest.approx(60000.0)
         assert ticker._prices["BTC-EUR"]["a"] == pytest.approx(60010.0)
         assert ticker._prices["BTC-EUR"]["b"] == pytest.approx(59990.0)
+        assert ticker._prices["BTC-EUR"]["v"] == pytest.approx(2500.5)
 
     def test_two_pairs_stored_independently(self, tmp_path):
         ticker = _make_ticker(tmp_path)

--- a/Tests/test_dataloader.py
+++ b/Tests/test_dataloader.py
@@ -17,16 +17,26 @@ N_ROWS = 200  # enough for a long rolling window in tests
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 def _make_csv_files(tmp_dir: str, n_rows: int = N_ROWS, pair: str = PAIR,
-                    introduce_nans: bool = False) -> dict:
-    """Write the three CSV files (a, b, c) that DataLoader expects and return
-    the loader_dict pointing at them."""
+                    introduce_nans: bool = False, include_volume: bool = True) -> dict:
+    """Write CSV files (a, b, c, and optionally v) that DataLoader expects."""
 
     dates = pd.date_range("2025-01-01", periods=n_rows, freq="1min")
     prices = np.linspace(40_000, 42_000, n_rows)
 
-    for suffix, multiplier in [("a", 1.001), ("b", 0.999), ("c", 1.0)]:
+    suffixes = [("a", 1.001), ("b", 0.999), ("c", 1.0)]
+    if include_volume:
+        # Simulate 24 h volume (e.g. BTC amounts, ranging 1–10)
+        volume = np.linspace(1.0, 10.0, n_rows)
+        suffixes.append(("v", None))
+
+    for item in suffixes:
+        suffix, multiplier = item
+        if suffix == "v":
+            values = volume
+        else:
+            values = prices * multiplier
         df = pd.DataFrame(
-            {"ticker_entry": suffix, pair: prices * multiplier},
+            {"ticker_entry": suffix, pair: values},
             index=dates,
         )
         df.index.name = "timestamp"
@@ -209,6 +219,38 @@ class TestMultiSource:
         loader = DataLoader(config)
         loader.load_csv_export()
         assert "BTC-EUR" in loader.ticker_current.columns
+
+
+class TestVolumeLoader:
+    """DataLoader correctly loads and exposes ticker_volume when v CSV exists."""
+
+    def test_ticker_volume_loaded(self, tmp_path):
+        config = _make_csv_files(str(tmp_path), include_volume=True)
+        loader = DataLoader(config)
+        loader.load_csv_export()
+        assert loader.ticker_volume is not None
+        assert PAIR in loader.ticker_volume.columns
+
+    def test_ticker_volume_no_nans(self, tmp_path):
+        config = _make_csv_files(str(tmp_path), include_volume=True)
+        loader = DataLoader(config)
+        loader.load_csv_export()
+        assert not loader.ticker_volume.isna().any().any()
+
+    def test_ticker_volume_none_when_missing(self, tmp_path):
+        """If no volume CSV exists, ticker_volume should be None (not an error)."""
+        config = _make_csv_files(str(tmp_path), include_volume=False)
+        loader = DataLoader(config)
+        loader.load_csv_export()
+        assert loader.ticker_volume is None
+
+    def test_ticker_volume_values_increase(self, tmp_path):
+        """Volume values should match the monotonically increasing test data."""
+        config = _make_csv_files(str(tmp_path), include_volume=True)
+        loader = DataLoader(config)
+        loader.load_csv_export()
+        # First value < last value (linspace 1→10)
+        assert loader.ticker_volume[PAIR].iloc[0] < loader.ticker_volume[PAIR].iloc[-1]
 
 
 class TestInterpolateNan:

--- a/Tests/test_exchange_tickers.py
+++ b/Tests/test_exchange_tickers.py
@@ -56,8 +56,10 @@ class TestBinanceTicker:
     def _binance_response(self):
         # Binance returns uppercase, no-hyphen symbols
         return [
-            {"symbol": "BTCEUR", "lastPrice": "60000.00", "askPrice": "60010.00", "bidPrice": "59990.00"},
-            {"symbol": "ETHBTC", "lastPrice": "0.050",    "askPrice": "0.0501",    "bidPrice": "0.0499"},
+            {"symbol": "BTCEUR", "lastPrice": "60000.00", "askPrice": "60010.00",
+             "bidPrice": "59990.00", "volume": "1234.5"},
+            {"symbol": "ETHBTC", "lastPrice": "0.050",    "askPrice": "0.0501",
+             "bidPrice": "0.0499", "volume": "5000.0"},
         ]
 
     def test_get_market_query_keyed_by_unified_pair(self, tmp_path):
@@ -69,6 +71,7 @@ class TestBinanceTicker:
         assert mq["BTC-EUR"]["c"] == pytest.approx(60000.0)
         assert mq["BTC-EUR"]["a"] == pytest.approx(60010.0)
         assert mq["BTC-EUR"]["b"] == pytest.approx(59990.0)
+        assert mq["BTC-EUR"]["v"] == pytest.approx(1234.5)
 
     def test_get_last_ticker_close(self, tmp_path):
         ticker = self._make(tmp_path)
@@ -108,7 +111,7 @@ class TestBinanceTicker:
         """Binance returns a plain dict (not a list) for single-symbol requests."""
         ticker = self._make(tmp_path)
         single = {"symbol": "BTCEUR", "lastPrice": "60000.00",
-                  "askPrice": "60010.00", "bidPrice": "59990.00"}
+                  "askPrice": "60010.00", "bidPrice": "59990.00", "volume": "500.0"}
         with patch("requests.get", return_value=_mock_response(single)):
             mq = ticker.get_market_query()
         assert "BTC-EUR" in mq
@@ -131,8 +134,8 @@ class TestCoinbaseTicker:
 
     def _response_for(self, pair: str):
         data = {
-            "BTC-EUR": {"price": "60000.00", "ask": "60010.00", "bid": "59990.00"},
-            "ETH-BTC": {"price": "0.050",    "ask": "0.0501",   "bid": "0.0499"},
+            "BTC-EUR": {"price": "60000.00", "ask": "60010.00", "bid": "59990.00", "volume": "800.0"},
+            "ETH-BTC": {"price": "0.050",    "ask": "0.0501",   "bid": "0.0499",   "volume": "3000.0"},
         }
         return data[pair]
 
@@ -145,6 +148,7 @@ class TestCoinbaseTicker:
         assert mq["BTC-EUR"]["c"] == pytest.approx(60000.0)
         assert mq["BTC-EUR"]["a"] == pytest.approx(60010.0)
         assert mq["BTC-EUR"]["b"] == pytest.approx(59990.0)
+        assert mq["BTC-EUR"]["v"] == pytest.approx(800.0)
 
     def test_partial_failure_still_returns_good_pairs(self, tmp_path):
         ticker = self._make(tmp_path)
@@ -183,8 +187,10 @@ class TestGeminiTicker:
 
     def _response_for(self, pair: str):
         data = {
-            "BTC-EUR": {"last": "60000.00", "ask": "60010.00", "bid": "59990.00"},
-            "ETH-BTC": {"last": "0.050",    "ask": "0.0501",   "bid": "0.0499"},
+            "BTC-EUR": {"last": "60000.00", "ask": "60010.00", "bid": "59990.00",
+                        "volume": {"BTC": "250.0", "EUR": "15000000", "timestamp": 1234567890}},
+            "ETH-BTC": {"last": "0.050",    "ask": "0.0501",   "bid": "0.0499",
+                        "volume": {"ETH": "5000.0", "BTC": "250.0", "timestamp": 1234567890}},
         }
         return data[pair]
 
@@ -196,6 +202,7 @@ class TestGeminiTicker:
         # Keys must be unified names, not Gemini's lowercase
         assert set(mq.keys()) == set(GEMINI_PAIRS)
         assert mq["BTC-EUR"]["c"] == pytest.approx(60000.0)
+        assert mq["BTC-EUR"]["v"] == pytest.approx(250.0)   # base-asset (BTC) volume
 
     def test_to_exchange_pair_converts_to_lowercase(self, tmp_path):
         """Gemini uses lowercase no-separator symbols internally."""
@@ -230,43 +237,37 @@ class TestMEXCTicker:
         from altotrader.ticker.mexcticker import MEXCTicker
         return MEXCTicker(pairs_yaml=_yaml_with_pairs(tmp_path, MEXC_PAIRS))
 
-    def _price_response(self):
-        # MEXC returns uppercase, no-hyphen symbols
+    def _24hr_response(self):
+        """MEXC /ticker/24hr response – single request with all fields."""
         return [
-            {"symbol": "BTCUSDT",  "price": "60000.00"},
-            {"symbol": "ETHBTC",   "price": "0.050"},
-            {"symbol": "OTHERUSD", "price": "1.0"},
+            {"symbol": "BTCUSDT",  "lastPrice": "60000.00", "askPrice": "60010.00",
+             "bidPrice": "59990.00", "volume": "1234.5"},
+            {"symbol": "ETHBTC",   "lastPrice": "0.050",    "askPrice": "0.0501",
+             "bidPrice": "0.0499", "volume": "5000.0"},
+            {"symbol": "OTHERUSD", "lastPrice": "1.0",      "askPrice": "1.01",
+             "bidPrice": "0.99",   "volume": "9999.0"},
         ]
 
-    def _book_response(self):
-        return [
-            {"symbol": "BTCUSDT",  "askPrice": "60010.00", "bidPrice": "59990.00"},
-            {"symbol": "ETHBTC",   "askPrice": "0.0501",   "bidPrice": "0.0499"},
-            {"symbol": "OTHERUSD", "askPrice": "1.01",     "bidPrice": "0.99"},
-        ]
-
-    def test_get_market_query_two_requests(self, tmp_path):
+    def test_get_market_query_one_request(self, tmp_path):
         ticker = self._make(tmp_path)
-        resps = [_mock_response(self._price_response()), _mock_response(self._book_response())]
-        with patch("requests.get", side_effect=resps) as mock_get:
+        with patch("requests.get", return_value=_mock_response(self._24hr_response())) as mock_get:
             ticker.get_market_query()
-        assert mock_get.call_count == 2
+        assert mock_get.call_count == 1
 
     def test_get_market_query_keyed_by_unified(self, tmp_path):
         ticker = self._make(tmp_path)
-        resps = [_mock_response(self._price_response()), _mock_response(self._book_response())]
-        with patch("requests.get", side_effect=resps):
+        with patch("requests.get", return_value=_mock_response(self._24hr_response())):
             mq = ticker.get_market_query()
         # Keys must be unified names ("BTC-USDT"), not exchange symbols ("BTCUSDT")
         assert set(mq.keys()) == set(MEXC_PAIRS)
         assert mq["BTC-USDT"]["c"] == pytest.approx(60000.0)
         assert mq["BTC-USDT"]["a"] == pytest.approx(60010.0)
         assert mq["BTC-USDT"]["b"] == pytest.approx(59990.0)
+        assert mq["BTC-USDT"]["v"] == pytest.approx(1234.5)
 
     def test_unknown_pair_excluded(self, tmp_path):
         ticker = self._make(tmp_path)
-        resps = [_mock_response(self._price_response()), _mock_response(self._book_response())]
-        with patch("requests.get", side_effect=resps):
+        with patch("requests.get", return_value=_mock_response(self._24hr_response())):
             mq = ticker.get_market_query()
         assert "OTHERUSD" not in mq
         assert "OTHER-USD" not in mq
@@ -280,15 +281,20 @@ class TestMEXCTicker:
 
     def test_get_last_ticker_ask(self, tmp_path):
         ticker = self._make(tmp_path)
-        resps = [_mock_response(self._price_response()), _mock_response(self._book_response())]
-        with patch("requests.get", side_effect=resps):
+        with patch("requests.get", return_value=_mock_response(self._24hr_response())):
             mq = ticker.get_market_query()
         df = ticker.get_last_ticker("a", market_query=mq)
         assert df["BTC-USDT"].iloc[0] == pytest.approx(60010.0)
 
+    def test_get_last_ticker_volume(self, tmp_path):
+        ticker = self._make(tmp_path)
+        with patch("requests.get", return_value=_mock_response(self._24hr_response())):
+            mq = ticker.get_market_query()
+        df = ticker.get_last_ticker("v", market_query=mq)
+        assert df["BTC-USDT"].iloc[0] == pytest.approx(1234.5)
+
     def test_timestamp_set(self, tmp_path):
         ticker = self._make(tmp_path)
-        resps = [_mock_response(self._price_response()), _mock_response(self._book_response())]
-        with patch("requests.get", side_effect=resps):
+        with patch("requests.get", return_value=_mock_response(self._24hr_response())):
             ticker.get_market_query()
         assert ticker.timestamp_last_fetch is not None

--- a/Tests/test_krakenticker.py
+++ b/Tests/test_krakenticker.py
@@ -47,7 +47,9 @@ def test_load_yaml():
 
 @needs_real_krakenex
 @patch.object(krakenex.API, 'query_public',
-              return_value={"result": {"XETHZEUR": {"c": [1743.55]}}})
+              return_value={"result": {
+                  "XETHZEUR": {"c": [1743.55], "v": ["100.0", "850.5"]},
+              }})
 def test_get_market_query(mock_query_public):
     test_file_path = os.path.join(os.path.dirname(
         __file__), 'mock_data/mock_pairs.yaml')
@@ -59,13 +61,15 @@ def test_get_market_query(mock_query_public):
     # Result must be keyed by the unified pair name
     assert ETH_EUR in market_query
     assert market_query[ETH_EUR]["c"][0] == 1743.55
+    # Volume is normalised to 24 h value at index 0
+    assert market_query[ETH_EUR]["v"][0] == pytest.approx(850.5)
 
 
 @needs_real_krakenex
 @patch.object(krakenex.API, 'query_public',
               return_value={"result": {
-                  "XETHZEUR": {"c": [1743.55], "a": [1744.00], "b": [1743.00]},
-                  "XXBTZEUR": {"c": [78230.1], "a": [78250.0], "b": [78210.0]},
+                  "XETHZEUR": {"c": [1743.55], "a": [1744.00], "b": [1743.00], "v": ["100.0", "850.5"]},
+                  "XXBTZEUR": {"c": [78230.1], "a": [78250.0], "b": [78210.0], "v": ["50.0",  "412.3"]},
               }})
 def test_get_market_price_valid(mock_query_public):
     test_file_path = os.path.join(os.path.dirname(

--- a/Tests/test_update_service.py
+++ b/Tests/test_update_service.py
@@ -177,5 +177,5 @@ class TestUpdatePairsTicker:
             )
 
         assert result is True
-        # 3 ticker entries (a, b, c) × 1 pair × 1 timestamp = 3 points total
-        assert sum(written_calls) == 3
+        # 4 ticker entries (a, b, c, v) × 1 pair × 1 timestamp = 4 points total
+        assert sum(written_calls) == 4

--- a/src/altotrader/backtest/backtest_engine.py
+++ b/src/altotrader/backtest/backtest_engine.py
@@ -20,6 +20,8 @@ class BacktestEngine:
         self.pair = f"{self.trading_currency}-{self.base_currency}"
         # Slippage applied on top of ask/bid spread (0.0005 = 0.05%)
         self.slippage_pct = backtest_config.get('slippage_pct', 0.0005)
+        # Optional volume filter: only enter if volume >= rolling mean over this window (minutes)
+        self.volume_filter_window: Optional[int] = backtest_config.get('volume_filter_window', None)
 
         setup_logging(log_filename='backtest.logs', log_dir=log_dir)
         self.logger = logging.getLogger(__name__)
@@ -39,6 +41,8 @@ class BacktestEngine:
         self.portfolio_view[self.pair]           = self.dataloader.ticker_current[self.pair]
         self.portfolio_view[self.pair + '_ask']  = self.dataloader.ticker_ask[self.pair]
         self.portfolio_view[self.pair + '_bid']  = self.dataloader.ticker_bid[self.pair]
+        if self.dataloader.ticker_volume is not None and self.pair in self.dataloader.ticker_volume.columns:
+            self.portfolio_view[self.pair + '_volume'] = self.dataloader.ticker_volume[self.pair]
 
         self.portfolio_view[self.base_currency]              = float(self.initial_invest)
         self.portfolio_view[self.trading_currency]           = 0.0
@@ -171,9 +175,15 @@ class BacktestEngine:
         Returns:
             dict with performance metrics
         """
+        vol_filter_active = (
+            self.volume_filter_window is not None
+            and self.dataloader.ticker_volume is not None
+            and self.pair in self.dataloader.ticker_volume.columns
+        )
         self.logger.info(
             f"Starting backtest | short={window_short}min | long={window_long}min | "
-            f"slippage={self.slippage_pct*100:.3f}%"
+            f"slippage={self.slippage_pct*100:.3f}% | "
+            f"volume_filter={'on (' + str(self.volume_filter_window) + 'min)' if vol_filter_active else 'off'}"
         )
         self._set_portfolio_view_df()
         self.dataloader.compute_rolling_means(window_short, window_long)
@@ -183,6 +193,12 @@ class BacktestEngine:
 
         self.portfolio_view['ma_short'] = ma_short
         self.portfolio_view['ma_long']  = ma_long
+
+        if vol_filter_active:
+            vol_ma = self.dataloader.ticker_volume[self.pair].rolling(
+                f'{self.volume_filter_window}min'
+            ).mean()
+            self.portfolio_view['_vol_ma'] = vol_ma
 
         valid = self.portfolio_view.dropna(subset=['ma_short', 'ma_long'])
 
@@ -214,7 +230,17 @@ class BacktestEngine:
             golden_cross = (prev_short <= prev_long) and (curr_short > curr_long)
             death_cross  = (prev_short >= prev_long) and (curr_short < curr_long)
 
-            if golden_cross and curr_position == 'out':
+            # Volume filter: only enter when volume >= rolling mean
+            volume_ok = True
+            if vol_filter_active and golden_cross:
+                vol_ma_val = self.portfolio_view.at[row.name, '_vol_ma']
+                curr_vol   = self.portfolio_view.at[row.name, self.pair + '_volume']
+                if pd.notna(vol_ma_val) and pd.notna(curr_vol):
+                    volume_ok = curr_vol >= vol_ma_val
+                else:
+                    volume_ok = False  # insufficient data → skip
+
+            if golden_cross and curr_position == 'out' and volume_ok:
                 pending_action = 'buy'
             elif death_cross and curr_position == 'in':
                 pending_action = 'sell'

--- a/src/altotrader/backtest/dataloader.py
+++ b/src/altotrader/backtest/dataloader.py
@@ -19,6 +19,7 @@ class DataLoader:
         self.ticker_current = None
         self.ticker_ask = None
         self.ticker_bid = None
+        self.ticker_volume = None
 
         self.rolling_ask_short = self.rolling_ask_long = None
         self.rolling_bid_short = self.rolling_bid_long = None
@@ -112,10 +113,22 @@ class DataLoader:
         self.ticker_bid     = load_and_merge("b")
         self.ticker_current = load_and_merge("c")
 
+        # Volume is optional – tolerate missing files gracefully
+        try:
+            self.ticker_volume = load_and_merge("v")
+        except RuntimeError:
+            self.logger.info(
+                "No volume ('v') CSV files found – ticker_volume will be None. "
+                "Re-export from InfluxDB to include volume data."
+            )
+            self.ticker_volume = None
+
         # fill NaN if any
         self.ticker_ask = self._iterpolate_nan(self.ticker_ask)
         self.ticker_bid = self._iterpolate_nan(self.ticker_bid)
         self.ticker_current = self._iterpolate_nan(self.ticker_current)
+        if self.ticker_volume is not None:
+            self.ticker_volume = self._iterpolate_nan(self.ticker_volume)
 
     def compute_rolling_means(self, window_short: int, window_long: int) -> None:
         """computes the rolling means for ask, bid, current dataframes with short and long
@@ -133,7 +146,7 @@ class DataLoader:
         self._window_short = window_short
 
         if self.ticker_current is None or self.ticker_ask is None or self.ticker_bid is None:
-            self.load_csv_export()
+            self.load_csv_export()  # also loads ticker_volume if available
 
         self.rolling_ask_short = self.ticker_ask.rolling(
             f'{window_short}min').mean()

--- a/src/altotrader/database/export_prices.py
+++ b/src/altotrader/database/export_prices.py
@@ -41,7 +41,7 @@ def export_prices(path_to_parquet: str,
         logger.error(f"Missing InfluxDB configuration: {', '.join(missing)}")
         return False
 
-    ticker_entries = ['a', 'b', 'c']  # ask, bid, current
+    ticker_entries = ['a', 'b', 'c', 'v']  # ask, bid, current, volume
 
     for ticker in ticker_entries:
         df_pivot = _query_with_retry(ticker, days_into_past, influx_config)

--- a/src/altotrader/database/update_service.py
+++ b/src/altotrader/database/update_service.py
@@ -42,7 +42,7 @@ class TickerUpdateService:
         Retries the Kraken API fetch up to _MAX_RETRIES times with exponential backoff.
 
         Args:
-            ticker_entry: 'a', 'b', or 'c' (or None for all three)
+            ticker_entry: 'a', 'b', 'c', or 'v' (or None for all four)
             bucket: InfluxDB bucket name (falls back to INFLUXDB_INIT_BUCKET env var)
             org: InfluxDB organization (falls back to INFLUXDB_INIT_ORG env var)
             url: InfluxDB URL (falls back to INFLUX_URL env var)
@@ -66,7 +66,7 @@ class TickerUpdateService:
                 raise ValueError(
                     f"Missing configuration: {', '.join(missing)}")
 
-            ticker_entries = [ticker_entry] if ticker_entry else ["a", "b", "c"]
+            ticker_entries = [ticker_entry] if ticker_entry else ["a", "b", "c", "v"]
             all_points = []
 
             market_query = self._fetch_market_query_with_retry()

--- a/src/altotrader/ticker/binance_ws_ticker.py
+++ b/src/altotrader/ticker/binance_ws_ticker.py
@@ -18,6 +18,7 @@ Protocol summary
   ``c``        Last trade price
   ``a``        Best ask price
   ``b``        Best bid price
+  ``v``        24 h base-asset volume
   ============ =============================
 
 - Server sends a WebSocket ping frame every 20 s; ``websocket-client``
@@ -84,7 +85,7 @@ class BinanceWsTicker(RestBaseTicker):
     def __init__(self, pairs_yaml: str, log_dir: str = "logs"):
         super().__init__(pairs_yaml, log_dir)
 
-        # Price cache: {SYMBOL (uppercase): {c, a, b}}
+        # Price cache: {unified_pair: {c, a, b, v}}
         self._prices: Dict[str, Dict[str, float]] = {}
         self._lock   = threading.Lock()
 
@@ -231,11 +232,12 @@ class BinanceWsTicker(RestBaseTicker):
             if symbol is None:
                 return
 
-            # Parse the three price fields
+            # Parse price and volume fields
             try:
                 c = float(tick["c"])   # last price
                 a = float(tick["a"])   # best ask
                 b = float(tick["b"])   # best bid
+                v = float(tick.get("v", 0.0))  # 24 h base-asset volume
             except (KeyError, ValueError, TypeError) as exc:
                 self.logger.warning(f"Price parse error for {symbol}: {exc}")
                 return
@@ -254,9 +256,9 @@ class BinanceWsTicker(RestBaseTicker):
                 return
 
             with self._lock:
-                self._prices[symbol] = {"c": c, "a": a, "b": b}
+                self._prices[symbol] = {"c": c, "a": a, "b": b, "v": v}
 
-            self.logger.debug(f"Tick {symbol}: c={c}, a={a}, b={b}")
+            self.logger.debug(f"Tick {symbol}: c={c}, a={a}, b={b}, v={v}")
 
         except Exception as exc:
             self.logger.error(

--- a/src/altotrader/ticker/binanceticker.py
+++ b/src/altotrader/ticker/binanceticker.py
@@ -52,6 +52,7 @@ class BinanceTicker(RestBaseTicker):
                     "c": float(item["lastPrice"]),
                     "a": float(item["askPrice"]),
                     "b": float(item["bidPrice"]),
+                    "v": float(item.get("volume", 0.0)),  # 24 h base-asset volume
                 }
 
             if result:
@@ -72,6 +73,6 @@ if __name__ == "__main__":
     ticker = BinanceTicker(pairs_yaml="Examples/binance_pairs.yaml")
     while True:
         mq = ticker.get_market_query()
-        for entry in ("c", "a", "b"):
+        for entry in ("c", "a", "b", "v"):
             print(ticker.get_last_ticker(ticker_entry=entry, market_query=mq))
         time.sleep(60)

--- a/src/altotrader/ticker/coinbaseticker.py
+++ b/src/altotrader/ticker/coinbaseticker.py
@@ -39,9 +39,11 @@ class CoinbaseTicker(RestBaseTicker):
                     "c": float(data["price"]),
                     "a": float(data["ask"]),
                     "b": float(data["bid"]),
+                    "v": float(data.get("volume", 0.0)),  # 24 h base-asset volume
                 }
                 self.logger.debug(
-                    f"{pair}: last={data['price']} ask={data['ask']} bid={data['bid']}"
+                    f"{pair}: last={data['price']} ask={data['ask']} bid={data['bid']} "
+                    f"vol={data.get('volume', 0)}"
                 )
             except Exception as exc:
                 self.logger.warning(f"Coinbase fetch failed for '{pair}': {exc}")
@@ -60,6 +62,6 @@ if __name__ == "__main__":
     ticker = CoinbaseTicker(pairs_yaml="Examples/coinbase_pairs.yaml")
     while True:
         mq = ticker.get_market_query()
-        for entry in ("c", "a", "b"):
+        for entry in ("c", "a", "b", "v"):
             print(ticker.get_last_ticker(ticker_entry=entry, market_query=mq))
         time.sleep(60)

--- a/src/altotrader/ticker/geminiticker.py
+++ b/src/altotrader/ticker/geminiticker.py
@@ -37,13 +37,18 @@ class GeminiTicker(RestBaseTicker):
             try:
                 ex_sym = self._to_exchange_pair(pair)   # btceur
                 data   = self._get(f"{_BASE_URL}/pubticker/{ex_sym}")
+                # Gemini volume dict: {"BTC": "100.5", "EUR": "5000000", "timestamp": ...}
+                base_currency = pair.split("-")[0]
+                v_dict = data.get("volume", {})
+                v = float(v_dict.get(base_currency, 0.0)) if isinstance(v_dict, dict) else 0.0
                 result[pair] = {
                     "c": float(data["last"]),
                     "a": float(data["ask"]),
                     "b": float(data["bid"]),
+                    "v": v,  # 24 h base-asset volume
                 }
                 self.logger.debug(
-                    f"{pair}: last={data['last']} ask={data['ask']} bid={data['bid']}"
+                    f"{pair}: last={data['last']} ask={data['ask']} bid={data['bid']} vol={v}"
                 )
             except Exception as exc:
                 self.logger.warning(f"Gemini fetch failed for '{pair}': {exc}")
@@ -62,6 +67,6 @@ if __name__ == "__main__":
     ticker = GeminiTicker(pairs_yaml="Examples/gemini_pairs.yaml")
     while True:
         mq = ticker.get_market_query()
-        for entry in ("c", "a", "b"):
+        for entry in ("c", "a", "b", "v"):
             print(ticker.get_last_ticker(ticker_entry=entry, market_query=mq))
         time.sleep(60)

--- a/src/altotrader/ticker/kraken_ws_ticker.py
+++ b/src/altotrader/ticker/kraken_ws_ticker.py
@@ -82,7 +82,7 @@ class KrakenWsTicker(BaseTicker):
         self.logger = logging.getLogger(__name__)
 
         # Latest prices keyed by WS pair name
-        self._prices: Dict[str, Dict[str, float]] = {}  # {ws_pair: {c, a, b}}
+        self._prices: Dict[str, Dict[str, float]] = {}  # {ws_pair: {c, a, b, v}}
         self._lock = threading.Lock()
 
         self._ws = None
@@ -132,7 +132,7 @@ class KrakenWsTicker(BaseTicker):
         """Return latest cached prices keyed by unified pair name.
 
         Returns a dict keyed by unified pair name (e.g. 'BTC-EUR'), with
-        sub-dicts for c/a/b (list format for KrakenTicker compatibility).
+        sub-dicts for c/a/b/v (list format for KrakenTicker compatibility).
         Returns an empty dict if no data has been received yet.
         """
         with self._lock:
@@ -144,6 +144,7 @@ class KrakenWsTicker(BaseTicker):
                         "c": [prices.get("c", 0.0)],
                         "a": [prices.get("a", 0.0)],
                         "b": [prices.get("b", 0.0)],
+                        "v": [prices.get("v", 0.0)],  # 24 h rolling volume
                     }
             if result:
                 self.timestamp_last_fetch = self.current_timestamp()
@@ -151,7 +152,7 @@ class KrakenWsTicker(BaseTicker):
 
     def get_last_ticker(self, ticker_entry: str, market_query: dict = None) -> pd.DataFrame:
         """Return a one-row DataFrame with the latest prices (same as KrakenTicker)."""
-        valid_entries = {"c", "a", "b"}
+        valid_entries = {"c", "a", "b", "v"}
         if ticker_entry not in valid_entries:
             raise ValueError(f"ticker_entry must be one of {valid_entries}")
 
@@ -246,7 +247,7 @@ class KrakenWsTicker(BaseTicker):
             ws_pair   = data[3]
             tick_data = data[1]
 
-            # Validate required fields before parsing
+            # Validate required price fields before parsing
             required_fields = ("c", "a", "b")
             if not isinstance(tick_data, dict) or not all(
                 k in tick_data and tick_data[k] for k in required_fields
@@ -261,6 +262,9 @@ class KrakenWsTicker(BaseTicker):
                 close_price = float(tick_data["c"][0])
                 ask_price   = float(tick_data["a"][0])
                 bid_price   = float(tick_data["b"][0])
+                # v = [volume_today, volume_24h]; take the 24 h rolling value
+                v_raw    = tick_data.get("v", [0.0, 0.0])
+                volume   = float(v_raw[1]) if len(v_raw) >= 2 else float(v_raw[0])
             except (ValueError, TypeError, IndexError) as exc:
                 self.logger.warning(
                     f"Could not parse tick prices for {ws_pair}: {exc}"
@@ -281,12 +285,13 @@ class KrakenWsTicker(BaseTicker):
                 )
                 return
 
-            # Extract close (c), ask (a), bid (b) – each is [price, volume]
+            # Store close, ask, bid, and 24 h volume
             with self._lock:
                 self._prices[ws_pair] = {
                     "c": close_price,
                     "a": ask_price,
                     "b": bid_price,
+                    "v": volume,
                 }
             self.logger.debug(f"Tick {ws_pair}: {self._prices[ws_pair]}")
 

--- a/src/altotrader/ticker/krakenticker.py
+++ b/src/altotrader/ticker/krakenticker.py
@@ -81,9 +81,9 @@ class KrakenTicker(BaseTicker):
                 unified = _REST_TO_UNIFIED.get(rest_key)
                 if unified is not None:
                     entry = dict(data)
-                    # Normalise volume: Kraken v = [today, 24h] – expose 24 h at index 0
+                    # Normalise volume: Kraken v = [today, 24h] – expose 24 h at index 0 as float
                     if "v" in entry and isinstance(entry["v"], list) and len(entry["v"]) >= 2:
-                        entry["v"] = [entry["v"][1]]
+                        entry["v"] = [float(entry["v"][1])]
                     result[unified] = entry
 
             return result

--- a/src/altotrader/ticker/krakenticker.py
+++ b/src/altotrader/ticker/krakenticker.py
@@ -63,8 +63,12 @@ class KrakenTicker(BaseTicker):
     def get_market_query(self) -> dict:
         """Fetch all Kraken ticker data and return it keyed by unified pair names.
 
+        The raw Kraken response uses list fields (e.g. ``c[0]`` = last price,
+        ``v[1]`` = 24 h rolling volume).  Volume is normalised so that index 0
+        always holds the 24 h value, consistent with how other entries are read.
+
         Returns:
-            ``{"BTC-EUR": {"c": [...], "a": [...], "b": [...]}, ...}``
+            ``{"BTC-EUR": {"c": [...], "a": [...], "b": [...], "v": [...]}, ...}``
         """
         try:
             response = self.k.query_public("Ticker")
@@ -76,7 +80,11 @@ class KrakenTicker(BaseTicker):
             for rest_key, data in raw.items():
                 unified = _REST_TO_UNIFIED.get(rest_key)
                 if unified is not None:
-                    result[unified] = data
+                    entry = dict(data)
+                    # Normalise volume: Kraken v = [today, 24h] – expose 24 h at index 0
+                    if "v" in entry and isinstance(entry["v"], list) and len(entry["v"]) >= 2:
+                        entry["v"] = [entry["v"][1]]
+                    result[unified] = entry
 
             return result
         except Exception as e:
@@ -96,7 +104,7 @@ class KrakenTicker(BaseTicker):
 
         self.logger.info(f"ticker_entry: {ticker_entry}")
 
-        valid_entries = {"c", "a", "b"}
+        valid_entries = {"c", "a", "b", "v"}
         if ticker_entry not in valid_entries:
             self.logger.error(
                 f"Invalid ticker_entry '{ticker_entry}'. Must be one of {valid_entries}.")

--- a/src/altotrader/ticker/mexcticker.py
+++ b/src/altotrader/ticker/mexcticker.py
@@ -1,13 +1,8 @@
 """MEXC REST ticker.
 
 MEXC's v3 API is largely compatible with Binance's API format.
-This ticker combines two lightweight endpoints:
-  - ``/api/v3/ticker/price``      → last price per symbol
-  - ``/api/v3/ticker/bookTicker`` → best bid/ask per symbol
-
-Both endpoints return data for all symbols when called without parameters,
-so we make only two requests per polling cycle regardless of how many pairs
-are configured.
+Uses the ``/api/v3/ticker/24hr`` endpoint which returns last price,
+ask, bid, and 24 h volume in a single request.
 
 Pair format: ``BTC-USDT``, ``ETH-BTC``, ``SOL-USDT`` …
 (unified hyphen-separated format; converted to ``BTCUSDT`` internally)
@@ -29,45 +24,36 @@ class MEXCTicker(RestBaseTicker):
     # _to_exchange_pair() inherited default: "BTC-USDT" → "BTCUSDT" ✓
 
     def get_market_query(self) -> Dict:
-        """Fetch last price + best bid/ask for all configured pairs.
+        """Fetch last price, bid/ask, and 24 h volume for all configured pairs.
 
-        Uses two bulk requests (price + bookTicker) and filters to the
-        configured pair list.
+        Uses a single bulk request to ``/ticker/24hr`` which provides all
+        fields (last price, ask, bid, volume) in one call.
 
         Returns:
-            Normalised dict ``{unified_pair: {c, a, b}}``.
+            Normalised dict ``{unified_pair: {c, a, b, v}}``.
         """
         try:
             reverse = self._exchange_to_unified_map()  # BTCUSDT → BTC-USDT
 
-            price_data = self._get(f"{_BASE_URL}/ticker/price")
-            book_data  = self._get(f"{_BASE_URL}/ticker/bookTicker")
-
-            # Build lookup maps  {exchange_symbol → value}
-            price_map: Dict[str, float] = {}
-            for item in (price_data if isinstance(price_data, list) else [price_data]):
-                price_map[item["symbol"]] = float(item["price"])
-
-            book_map: Dict[str, Dict] = {}
-            for item in (book_data if isinstance(book_data, list) else [book_data]):
-                book_map[item["symbol"]] = {
-                    "a": float(item["askPrice"]),
-                    "b": float(item["bidPrice"]),
-                }
+            ticker_data = self._get(f"{_BASE_URL}/ticker/24hr")
+            if isinstance(ticker_data, dict):
+                ticker_data = [ticker_data]  # single-symbol response
 
             result: Dict = {}
-            for ex_sym, unified in reverse.items():
-                if ex_sym not in price_map or ex_sym not in book_map:
-                    self.logger.warning(f"MEXC: no data for pair '{unified}' ({ex_sym})")
+            for item in (ticker_data if isinstance(ticker_data, list) else []):
+                ex_sym  = item.get("symbol", "")
+                unified = reverse.get(ex_sym)
+                if unified is None:
                     continue
                 result[unified] = {
-                    "c": price_map[ex_sym],
-                    "a": book_map[ex_sym]["a"],
-                    "b": book_map[ex_sym]["b"],
+                    "c": float(item["lastPrice"]),
+                    "a": float(item["askPrice"]),
+                    "b": float(item["bidPrice"]),
+                    "v": float(item.get("volume", 0.0)),  # 24 h base-asset volume
                 }
                 self.logger.debug(
-                    f"{unified}: last={price_map[ex_sym]} "
-                    f"ask={book_map[ex_sym]['a']} bid={book_map[ex_sym]['b']}"
+                    f"{unified}: last={item['lastPrice']} ask={item['askPrice']} "
+                    f"bid={item['bidPrice']} vol={item.get('volume', 0)}"
                 )
 
             if result:
@@ -88,6 +74,6 @@ if __name__ == "__main__":
     ticker = MEXCTicker(pairs_yaml="Examples/mexc_pairs.yaml")
     while True:
         mq = ticker.get_market_query()
-        for entry in ("c", "a", "b"):
+        for entry in ("c", "a", "b", "v"):
             print(ticker.get_last_ticker(ticker_entry=entry, market_query=mq))
         time.sleep(60)

--- a/src/altotrader/ticker/rest_base_ticker.py
+++ b/src/altotrader/ticker/rest_base_ticker.py
@@ -13,6 +13,10 @@ a dict in the normalised format::
     }
 
 ``get_last_ticker()`` is provided here and works identically for every exchange.
+
+The normalised ``get_market_query()`` dict must contain at least the keys
+``c``, ``a``, and ``b`` (float).  Adding ``v`` (24 h base-asset volume) is
+optional but recommended – it is stored as a 4th ticker_entry in InfluxDB.
 """
 from __future__ import annotations
 
@@ -93,7 +97,7 @@ class RestBaseTicker(BaseTicker):
             DataFrame with a single timestamp row and one column per pair.
             Empty DataFrame on failure.
         """
-        valid_entries = {"c", "a", "b"}
+        valid_entries = {"c", "a", "b", "v"}
         if ticker_entry not in valid_entries:
             raise ValueError(
                 f"Invalid ticker_entry '{ticker_entry}'. Must be one of {valid_entries}."


### PR DESCRIPTION
## Summary

- All REST tickers (Binance, Coinbase, Gemini, MEXC, Kraken) now return `"v"` (24 h base-asset volume) in `get_market_query()`
- MEXC refactored from two-request approach to single `/ticker/24hr` call (provides c/a/b/v in one round-trip)
- KrakenTicker normalises `v = [today, 24h]` → `[24h]` so `get_last_ticker` uses index 0 consistently for all entries
- KrakenWsTicker and BinanceWsTicker parse and cache volume from their WS events
- `TickerUpdateService` streams `["a", "b", "c", "v"]` to InfluxDB
- `export_prices.py` exports all 4 ticker entries to CSV
- `DataLoader` loads `ticker_volume` from `_v.csv` files; sets `ticker_volume=None` when files don't exist (backward compatible)
- `BacktestEngine` accepts optional `volume_filter_window` config: BUY signals are skipped when current volume < rolling mean over that window

## Test plan

- [ ] All 109 tests pass (`python -m pytest Tests/ -q`)
- [ ] Stream live data and verify `v` appears in InfluxDB alongside `a`, `b`, `c`
- [ ] Re-export from InfluxDB and confirm `_v.csv` files are created
- [ ] Run backtest with `volume_filter_window` set and verify fewer trades are triggered in low-volume periods

https://claude.ai/code/session_01HQU7KNPmCQP8eZm9DcY7cf